### PR TITLE
Updating and Fixing Input Device Configurations and renaming refactor (OSK-7)

### DIFF
--- a/src/OSK.Inputs.UnitTests/Internal/ApplicationUserTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/ApplicationUserTests.cs
@@ -27,21 +27,21 @@ public class ApplicationUserTests
     {
         _deviceConfigurations = [];
 
-        var mockController = new Mock<IInputDeviceConfiguration>();
-        mockController.SetupGet(m => m.ControllerName)
+        var mockDevice = new Mock<IInputDeviceConfiguration>();
+        mockDevice.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockController.SetupGet(m => m.Inputs)
+        mockDevice.SetupGet(m => m.Inputs)
             .Returns([]);
 
-        _deviceConfigurations.Add(mockController.Object);
+        _deviceConfigurations.Add(mockDevice.Object);
 
-        var mockController2 = new Mock<IInputDeviceConfiguration>();
-        mockController2.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("NewController"));
-        mockController2.SetupGet(m => m.Inputs)
+        var mockDevice2 = new Mock<IInputDeviceConfiguration>();
+        mockDevice2.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("NewDevice"));
+        mockDevice2.SetupGet(m => m.Inputs)
             .Returns([]);
 
-        _deviceConfigurations.Add(mockController2.Object);
+        _deviceConfigurations.Add(mockDevice2.Object);
 
         _testScheme = new InputScheme("Abc", new InputDeviceName("abc"), "abc", false, []);
         _testDefinition = new InputDefinition("Abc", [new InputAction("abc", _ => ValueTask.CompletedTask, null)], [ _testScheme ]);
@@ -63,33 +63,33 @@ public class ApplicationUserTests
 
     #endregion
 
-    #region ControllerIdentifiers
+    #region DeviceIdentifiers
 
     [Fact]
-    public void ControllerIdentifiers_NoInputControllers_ReturnsEmptyList()
+    public void DeviceIdentifiers_NoInputDevices_ReturnsEmptyList()
     {
         // Arrange/Act/Assert
-        Assert.Empty(_user.ControllerIdentifiers);
+        Assert.Empty(_user.DeviceIdentifiers);
     }
 
     [Fact]
-    public void ControllerIdentifiers_HasInputControllers_ReturnsControllerIdentifiers()
+    public void DeviceIdentifiers_HasInputDevices_ReturnsDeviceIdentifiers()
     {
         // Arrange
-        Inputs.Internal.InputDevice[] controllers = [
+        Inputs.Internal.InputDevice[] devices = [
             new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), Mock.Of<IInputReader>()),
             new Inputs.Internal.InputDevice(new InputDeviceIdentifier(234, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), Mock.Of<IInputReader>()),
         ];
 
-        _user.AddInputControllers(controllers);
+        _user.AddInputDevices(devices);
 
         // Act
-        var result = _user.ControllerIdentifiers;
+        var result = _user.DeviceIdentifiers;
 
         // Assert
-        foreach (var controller in controllers)
+        foreach (var device in devices)
         {
-            Assert.Contains(result, identifier => identifier == controller.DeviceIdentifier);
+            Assert.Contains(result, identifier => identifier == device.DeviceIdentifier);
         }
     }
 
@@ -109,7 +109,7 @@ public class ApplicationUserTests
     #region GetActiveInputScheme
 
     [Fact]
-    public void GetActiveInputScheme_NoSchemeForControllerName_ReturnsNull()
+    public void GetActiveInputScheme_NoSchemeForDeviceName_ReturnsNull()
     {
         // Arrange/Act/Assert
         Assert.Null(_user.GetActiveInputScheme(new InputDeviceName("nope")));
@@ -119,7 +119,7 @@ public class ApplicationUserTests
     public void GetActiveInputScheme_ValidInputScheme_ReturnsScheme()
     {
         // Arrange/Act
-        var result = _user.GetActiveInputScheme(_testScheme.ControllerName);
+        var result = _user.GetActiveInputScheme(_testScheme.DeviceName);
 
         // Assert
         Assert.Equal(_testScheme, result);
@@ -127,60 +127,60 @@ public class ApplicationUserTests
 
     #endregion
 
-    #region TryGetController
+    #region TryGetDevice
 
     [Fact]
-    public void TryGetController_ControllerNameNotFound_ReturnsFalse()
+    public void TryGetDevice_DeviceNameNotFound_ReturnsFalse()
     {
         // Arrange/Act
-        var result = _user.TryGetController(123, out var controller);
+        var result = _user.TryGetDevice(123, out var device);
 
         // Assert
         Assert.False(result);
-        Assert.Null(controller);
+        Assert.Null(device);
     }
 
     [Fact]
-    public void TryGetController_ValidController_ReturnsTrue()
+    public void TryGetDevice_ValidDevice_ReturnsTrue()
     {
         // Arrange
-        var controller = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), Mock.Of<IInputReader>());
+        var device = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), Mock.Of<IInputReader>());
 
-        _user.AddInputControllers(controller);
+        _user.AddInputDevices(device);
 
         // Act
-        var result = _user.TryGetController(controller.DeviceIdentifier.DeviceId, out var actualController);
+        var result = _user.TryGetDevice(device.DeviceIdentifier.DeviceId, out var actualDevice);
 
         // Assert
         Assert.True(result);
-        Assert.Equal(controller, actualController);
+        Assert.Equal(device, actualDevice);
     }
 
     #endregion
 
-    #region RemoveInputController
+    #region RemoveInputDevice
 
     [Fact]
-    public void RemoveInputController_ControllerIdNotInDataSet_ReturnsSuccessfully()
+    public void RemoveInputDevice_DeviceIdNotInDataSet_ReturnsSuccessfully()
     {
         // Arrange/Act
-        _user.RemoveInputController(new InputDeviceIdentifier());
+        _user.RemoveInputDevice(new InputDeviceIdentifier());
     }
 
     [Fact]
-    public void RemoveInputController_ValidControllerId_ReturnsSuccessfully()
+    public void RemoveInputDevice_ValidDeviceId_ReturnsSuccessfully()
     {
         // Arrange
         var mockInputReader = new Mock<IInputReader>();
-        var controller = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), mockInputReader.Object);
+        var device = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), mockInputReader.Object);
 
-        _user.AddInputControllers(controller);
+        _user.AddInputDevices(device);
 
         // Act
-        _user.RemoveInputController(controller.DeviceIdentifier);
+        _user.RemoveInputDevice(device.DeviceIdentifier);
 
         // Assert
-        Assert.False(_user.TryGetController(controller.DeviceIdentifier.DeviceId, out _));
+        Assert.False(_user.TryGetDevice(device.DeviceIdentifier.DeviceId, out _));
         mockInputReader.Verify(m => m.Dispose(), Times.Once);
     }
 
@@ -192,7 +192,7 @@ public class ApplicationUserTests
     public void SetActiveInputSchemes_OverwritesOriginalData()
     {
         // Arrange
-        var newTestScheme = new InputScheme("whatdayaknow", "NewController", "NewScheme", false, []);
+        var newTestScheme = new InputScheme("whatdayaknow", "NewDevice", "NewScheme", false, []);
         var newTestDefinition = new InputDefinition("whatdayaknow", [], [ newTestScheme ]);
 
         // Act
@@ -200,8 +200,8 @@ public class ApplicationUserTests
 
         // Assert
         Assert.Equal(newTestDefinition, _user.ActiveInputDefinition);
-        Assert.Null(_user.GetActiveInputScheme(_testScheme.ControllerName));
-        Assert.Equal(newTestScheme, _user.GetActiveInputScheme(newTestScheme.ControllerName));
+        Assert.Null(_user.GetActiveInputScheme(_testScheme.DeviceName));
+        Assert.Equal(newTestScheme, _user.GetActiveInputScheme(newTestScheme.DeviceName));
     }
 
     #endregion
@@ -223,15 +223,15 @@ public class ApplicationUserTests
     }
 
     [Fact]
-    public async Task ReadInputsAsync_NoActiveInputController_NoControllersReadInput_ReturnsEmptyList()
+    public async Task ReadInputsAsync_NoActiveInputDevice_NoDevicesReadInput_ReturnsEmptyList()
     {
         // Arrange
         var noInputReader = new Mock<IInputReader>();
-        Inputs.Internal.InputDevice[] controllers = [
+        Inputs.Internal.InputDevice[] devices = [
             new Inputs.Internal.InputDevice(new InputDeviceIdentifier(), Mock.Of<IInputDeviceConfiguration>(), noInputReader.Object)
         ];
 
-        _user.AddInputControllers(controllers);
+        _user.AddInputDevices(devices);
 
         // Act
         var result = await _user.ReadInputsAsync();
@@ -241,13 +241,13 @@ public class ApplicationUserTests
     }
 
     [Fact]
-    public async Task ReadInputsAsync_NoActiveInputController_ControllerReturnsInput_ReturnsExpectedList_TriggersActiveControllerChangedEvent()
+    public async Task ReadInputsAsync_NoActiveInputDevice_DeviceReturnsInput_ReturnsExpectedList_TriggersActiveDeviceChangedEvent()
     {
         // Arrange
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Id).Returns(1);
 
-        var controllerIdentifier = new InputDeviceIdentifier(1, new InputDeviceName("abc"));
+        var deviceIdentifier = new InputDeviceIdentifier(1, new InputDeviceName("abc"));
         var inputReader = new Mock<IInputReader>();
         inputReader.Setup(m => m.ReadInputsAsync(It.IsAny<UserInputReadContext>(), It.IsAny<CancellationToken>()))
             .Callback((UserInputReadContext readContext, CancellationToken _) =>
@@ -256,21 +256,21 @@ public class ApplicationUserTests
                     InputPhase.Start, Vector2.Zero);
             });
 
-        var controller = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(1, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader.Object);
-        Inputs.Internal.InputDevice[] controllers = [
-            controller
+        var device = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(1, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader.Object);
+        Inputs.Internal.InputDevice[] devices = [
+            device
         ];
 
         var eventCalled = false;
-        _user.OnActiveInputControllerChanged += (userId, inputController) =>
+        _user.OnActiveInputDeviceChanged += (userId, inputDevice) =>
         {
             Assert.Equal(userId, _user.Id);
-            Assert.Equal(controller, inputController);
+            Assert.Equal(device, inputDevice);
 
             eventCalled = true;
         };
 
-        _user.AddInputControllers(controllers);
+        _user.AddInputDevices(devices);
 
         // Act
         var result = await _user.ReadInputsAsync();
@@ -281,13 +281,13 @@ public class ApplicationUserTests
     }
 
     [Fact]
-    public async Task ReadInputsAsync_ActiveInputController_ControllerReturnsInputSkipsOtherControllers_ReturnsExpectedList()
+    public async Task ReadInputsAsync_ActiveInputDevice_DeviceReturnsInputSkipsOtherDevices_ReturnsExpectedList()
     {
         // Arrange
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Id).Returns(1);
 
-        var controllerIdentifier = new InputDeviceIdentifier(1, new InputDeviceName("abc"));
+        var deviceIdentifier = new InputDeviceIdentifier(1, new InputDeviceName("abc"));
         var inputReader1 = new Mock<IInputReader>();
         inputReader1.Setup(m => m.ReadInputsAsync(It.IsAny<UserInputReadContext>(), It.IsAny<CancellationToken>()))
             .Callback((UserInputReadContext readContext, CancellationToken _) =>
@@ -296,15 +296,15 @@ public class ApplicationUserTests
                     InputPhase.Start, Vector2.Zero);
             });
 
-        var controller1 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(1, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader1.Object);
-        _user.AddInputControllers(controller1);
+        var device1 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(1, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader1.Object);
+        _user.AddInputDevices(device1);
         await _user.ReadInputsAsync();
 
-        var controller2 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(2, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), Mock.Of<IInputReader>());
-        _user.AddInputControllers(controller2);
+        var device2 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(2, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), Mock.Of<IInputReader>());
+        _user.AddInputDevices(device2);
 
         var eventCalled = false;
-        _user.OnActiveInputControllerChanged += (userId, inputController) =>
+        _user.OnActiveInputDeviceChanged += (userId, inputDevice) =>
         {
             throw new InvalidOperationException("Should not be hit");
         };
@@ -318,13 +318,13 @@ public class ApplicationUserTests
     }
 
     [Fact]
-    public async Task ReadInputsAsync_ActiveInputController_ControllerDoesNotReturnInput_OtherControllersReturnInputSwitchesActiveController_ReturnsExpectedList()
+    public async Task ReadInputsAsync_ActiveInputDevice_DeviceDoesNotReturnInput_OtherDevicesReturnInputSwitchesActiveDevice_ReturnsExpectedList()
     {
         // Arrange
         var inputReader1 = new Mock<IInputReader>();
         inputReader1.Setup(m => m.ReadInputsAsync(It.IsAny<UserInputReadContext>(), It.IsAny<CancellationToken>()));
-        var controller1 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(1, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader1.Object);
-        _user.AddInputControllers(controller1);
+        var device1 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(1, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader1.Object);
+        _user.AddInputDevices(device1);
 
         var inputReader2 = new Mock<IInputReader>();
         inputReader2.Setup(m => m.ReadInputsAsync(It.IsAny<UserInputReadContext>(), It.IsAny<CancellationToken>()))
@@ -333,14 +333,14 @@ public class ApplicationUserTests
                 readContext.ActivateInput(new InputActionMapPair(Mock.Of<IInput>(), new InputActionMap("abc", 1, InputPhase.Start)),
                     InputPhase.Start, Vector2.Zero);
             });
-        var controller2 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(2, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader2.Object);
-        _user.AddInputControllers(controller2);
+        var device2 = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(2, new InputDeviceName("abc")), Mock.Of<IInputDeviceConfiguration>(), inputReader2.Object);
+        _user.AddInputDevices(device2);
 
         var eventCalled = false;
-        _user.OnActiveInputControllerChanged += (userId, inputController) =>
+        _user.OnActiveInputDeviceChanged += (userId, inputDevice) =>
         {
             Assert.Equal(userId, _user.Id);
-            Assert.Equal(controller2, inputController);
+            Assert.Equal(device2, inputDevice);
 
             eventCalled = true;
         };
@@ -355,25 +355,25 @@ public class ApplicationUserTests
 
     #endregion
 
-    #region OnInputControllerConnected
+    #region OnInputDeviceConnected
 
     [Fact]
-    public void OnInputControllerConnected_InputReaderEventTriggered_TriggersUserEvent()
+    public void OnInputDeviceConnected_InputReaderEventTriggered_TriggersUserEvent()
     {
         // Arrange
         var inputParameters = new InputReaderParameters(new InputDeviceIdentifier(123, new InputDeviceName("abc")), Mock.Of<IEnumerable<IInput>>());
         var testInputReader = new TestInputReader(inputParameters);
-        var controller = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), testInputReader);
+        var device = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), testInputReader);
 
-        _user.AddInputControllers(controller);
+        _user.AddInputDevices(device);
 
         var eventCalled = false;
 
-        _user.OnInputControllerConnected += (userId, inputController) =>
+        _user.OnInputDeviceConnected += (userId, inputDevice) =>
         {
             eventCalled = true;
 
-            Assert.Equal(controller, inputController);
+            Assert.Equal(device, inputDevice);
             Assert.Equal(_user.Id, userId);
         };
 
@@ -386,25 +386,25 @@ public class ApplicationUserTests
 
     #endregion
 
-    #region OnInputControllerDisconnected
+    #region OnInputDeviceDisconnected
 
     [Fact]
-    public void OnInputControllerDisconnected_InputReaderEventTriggered_TriggersUserEvent()
+    public void OnInputDeviceDisconnected_InputReaderEventTriggered_TriggersUserEvent()
     {
         // Arrange
         var inputParameters = new InputReaderParameters(new InputDeviceIdentifier(123, new InputDeviceName("abc")), Mock.Of<IEnumerable<IInput>>());
         var testInputReader = new TestInputReader(inputParameters);
-        var controller = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), testInputReader);
+        var device = new Inputs.Internal.InputDevice(new InputDeviceIdentifier(123, new InputDeviceName("test")), Mock.Of<IInputDeviceConfiguration>(), testInputReader);
 
-        _user.AddInputControllers(controller);
+        _user.AddInputDevices(device);
 
         var eventCalled = false;
 
-        _user.OnInputControllerDisconnected += (userId, inputController) =>
+        _user.OnInputDeviceDisconnected += (userId, inputDevice) =>
         {
             eventCalled = true;
 
-            Assert.Equal(controller, inputController);
+            Assert.Equal(device, inputDevice);
             Assert.Equal(_user.Id, userId);
         };
 

--- a/src/OSK.Inputs.UnitTests/Internal/InputSystemConfigurationTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/InputSystemConfigurationTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using OSK.Inputs.Models.Configuration;
+using OSK.Inputs.UnitTests._Helpers;
+using Xunit;
+
+namespace OSK.Inputs.UnitTests.Internal;
+public class InputSystemConfigurationTests
+{
+    [Fact]
+    public void InputSystemConfigurationTests_AddInputSystemAndInputDevices_NoErrors()
+    {
+        // Arrange
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddInputs(builder =>
+        {
+            builder.AddKeyboard<TestInputReader>(_ => { });
+            builder.AddMouse<TestInputReader>(_ => { });
+            builder.AddPlayStationController<TestInputReader>(_ => { });
+            builder.AddXboxController<TestInputReader>(_ => { });
+            builder.AddSensorController<TestInputReader>(_ => { });
+
+            builder.AddInputDefinition("Test", definition =>
+            {
+                definition.AddAction("Trigger", _ => ValueTask.CompletedTask);
+                definition.AddInputScheme(Keyboard.KeyboardName, "abc", scheme =>
+                {
+                    scheme.AssignStartAction(Keyboard.W, "Trigger");
+                });
+            });
+        });
+
+        // Act/Assert
+        serviceCollection.BuildServiceProvider();
+    }
+}

--- a/src/OSK.Inputs.UnitTests/Internal/Services/InMemoryInputSchemeRepositoryTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InMemoryInputSchemeRepositoryTests.cs
@@ -49,8 +49,8 @@ public class InMemoryInputSchemeRepositoryTests
         Assert.True(result.IsSuccessful);
 
         Assert.Single(_repository._customInputSchemes);
-        Assert.True(_repository._customInputSchemes.TryGetValue(inputScheme.InputDefinitionName, out var controllerSchemeLookup));
-        Assert.True(controllerSchemeLookup.TryGetValue(inputScheme.ControllerName.Name, out var schemeLookup));
+        Assert.True(_repository._customInputSchemes.TryGetValue(inputScheme.InputDefinitionName, out var deviceSchemeLookup));
+        Assert.True(deviceSchemeLookup.TryGetValue(inputScheme.DeviceName.Name, out var schemeLookup));
         Assert.True(schemeLookup.TryGetValue(inputScheme.SchemeName, out var scheme));
         Assert.Equal(inputScheme, scheme);
     }
@@ -71,8 +71,8 @@ public class InMemoryInputSchemeRepositoryTests
         Assert.True(result.IsSuccessful);
 
         Assert.Single(_repository._customInputSchemes);
-        Assert.True(_repository._customInputSchemes.TryGetValue(inputScheme.InputDefinitionName, out var controllerSchemeLookup));
-        Assert.True(controllerSchemeLookup.TryGetValue(inputScheme.ControllerName.Name, out var schemeLookup));
+        Assert.True(_repository._customInputSchemes.TryGetValue(inputScheme.InputDefinitionName, out var deviceSchemeLookup));
+        Assert.True(deviceSchemeLookup.TryGetValue(inputScheme.DeviceName.Name, out var schemeLookup));
         Assert.True(schemeLookup.TryGetValue(inputScheme.SchemeName, out var scheme));
         Assert.Equal(inputScheme2, scheme);
     }
@@ -181,7 +181,7 @@ public class InMemoryInputSchemeRepositoryTests
         await _repository.SaveCustomInputSchemeAsync(inputScheme.InputDefinitionName, inputScheme);
 
         // Act
-        var result = await _repository.GetCustomInputSchemeAsync(inputScheme.InputDefinitionName, inputScheme.ControllerName, inputScheme.SchemeName);
+        var result = await _repository.GetCustomInputSchemeAsync(inputScheme.InputDefinitionName, inputScheme.DeviceName, inputScheme.SchemeName);
 
         // Assert
         Assert.True(result.IsSuccessful);
@@ -237,7 +237,7 @@ public class InMemoryInputSchemeRepositoryTests
         await _repository.SaveCustomInputSchemeAsync(inputScheme.InputDefinitionName, inputScheme);
 
         // Act
-        var result = await _repository.DeleteCustomInputSchemeAsync(inputScheme.InputDefinitionName, inputScheme.ControllerName, inputScheme.SchemeName);
+        var result = await _repository.DeleteCustomInputSchemeAsync(inputScheme.InputDefinitionName, inputScheme.DeviceName, inputScheme.SchemeName);
 
         // Assert
         Assert.True(result.IsSuccessful);
@@ -269,8 +269,8 @@ public class InMemoryInputSchemeRepositoryTests
 
         Assert.Single(_repository._activeSchemes);
         Assert.True(_repository._activeSchemes.TryGetValue(activeScheme.UserId, out var userInputDefinitionSchemeLookup));
-        Assert.True(userInputDefinitionSchemeLookup.TryGetValue(activeScheme.InputDefinitionName, out var controllerSchemeLookup));
-        Assert.True(controllerSchemeLookup.TryGetValue(activeScheme.ActiveInputSchemeName, out var userActiveScheme));
+        Assert.True(userInputDefinitionSchemeLookup.TryGetValue(activeScheme.InputDefinitionName, out var deviceSchemeLookup));
+        Assert.True(deviceSchemeLookup.TryGetValue(activeScheme.ActiveInputSchemeName, out var userActiveScheme));
 
         Assert.Equal(activeScheme, userActiveScheme);
     }
@@ -292,8 +292,8 @@ public class InMemoryInputSchemeRepositoryTests
 
         Assert.Single(_repository._activeSchemes);
         Assert.True(_repository._activeSchemes.TryGetValue(activeScheme.UserId, out var userInputDefinitionSchemeLookup));
-        Assert.True(userInputDefinitionSchemeLookup.TryGetValue(activeScheme.InputDefinitionName, out var controllerSchemeLookup));
-        Assert.True(controllerSchemeLookup.TryGetValue(activeScheme.ActiveInputSchemeName, out var userActiveScheme));
+        Assert.True(userInputDefinitionSchemeLookup.TryGetValue(activeScheme.InputDefinitionName, out var deviceSchemeLookup));
+        Assert.True(deviceSchemeLookup.TryGetValue(activeScheme.ActiveInputSchemeName, out var userActiveScheme));
 
         Assert.Equal(activeScheme2, userActiveScheme);
     }

--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputDefinitionBuilderTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputDefinitionBuilderTests.cs
@@ -88,7 +88,7 @@ public class InputDefinitionBuilderTests
     public void AddInputScheme_ControllerNameIsNotASupportController_ThrowsInvalidOperationException()
     {
         // Arrange
-        _mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        _mockControllerConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
 
         // Act/Assert
@@ -102,7 +102,7 @@ public class InputDefinitionBuilderTests
     public void AddInputScheme_InvalidSchemeName_ThrowsArgumentException(string? schemeName)
     {
         // Arrange
-        _mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        _mockControllerConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
 
         // Act/Assert
@@ -120,24 +120,24 @@ public class InputDefinitionBuilderTests
     public void AddInputScheme_SchemeNameAlreadyAdded_ThrowsDuplicateNameException()
     {
         // Arrange
-        _mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        _mockControllerConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
 
-        _builder.AddInputScheme(_mockControllerConfiguration1.Object.ControllerName, "abc", _ => { });
+        _builder.AddInputScheme(_mockControllerConfiguration1.Object.DeviceName, "abc", _ => { });
 
         // Act/Assert
-        Assert.Throws<DuplicateNameException>(() => _builder.AddInputScheme(_mockControllerConfiguration1.Object.ControllerName, "abc", _ => { }));
+        Assert.Throws<DuplicateNameException>(() => _builder.AddInputScheme(_mockControllerConfiguration1.Object.DeviceName, "abc", _ => { }));
     }
 
     [Fact]
     public void AddInputScheme_Valid_ReturnsSuccessfully()
     {
         // Arrange
-        _mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        _mockControllerConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
 
         // Act/Assert
-        _builder.AddInputScheme(_mockControllerConfiguration1.Object.ControllerName, "abc", _ => { });
+        _builder.AddInputScheme(_mockControllerConfiguration1.Object.DeviceName, "abc", _ => { });
     }
 
     #endregion
@@ -153,15 +153,15 @@ public class InputDefinitionBuilderTests
         _builder.AddAction(action1);
         _builder.AddAction(action2);
 
-        _mockControllerConfiguration1.Setup(m => m.ControllerName)
+        _mockControllerConfiguration1.Setup(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        _mockControllerConfiguration2.Setup(m => m.ControllerName)
+        _mockControllerConfiguration2.Setup(m => m.DeviceName)
             .Returns(new InputDeviceName("def"));
 
-        _builder.AddInputScheme(_mockControllerConfiguration1.Object.ControllerName, "Scheme1", _ => { });
-        _builder.AddInputScheme(_mockControllerConfiguration1.Object.ControllerName, "Scheme2", _ => { });
+        _builder.AddInputScheme(_mockControllerConfiguration1.Object.DeviceName, "Scheme1", _ => { });
+        _builder.AddInputScheme(_mockControllerConfiguration1.Object.DeviceName, "Scheme2", _ => { });
 
-        _builder.AddInputScheme(_mockControllerConfiguration2.Object.ControllerName, "Scheme1", _ => { });
+        _builder.AddInputScheme(_mockControllerConfiguration2.Object.DeviceName, "Scheme1", _ => { });
 
         // Act
         var definition = _builder.Build();
@@ -175,9 +175,9 @@ public class InputDefinitionBuilderTests
         Assert.Contains(action2, definition.InputActions);
 
         Assert.Equal(3, definition.InputSchemes.Count());
-        Assert.Contains(definition.InputSchemes, scheme => scheme.ControllerName == _mockControllerConfiguration1.Object.ControllerName && scheme.SchemeName == "Scheme1");
-        Assert.Contains(definition.InputSchemes, scheme => scheme.ControllerName == _mockControllerConfiguration1.Object.ControllerName && scheme.SchemeName == "Scheme2");
-        Assert.Contains(definition.InputSchemes, scheme => scheme.ControllerName == _mockControllerConfiguration2.Object.ControllerName && scheme.SchemeName == "Scheme1");
+        Assert.Contains(definition.InputSchemes, scheme => scheme.DeviceName == _mockControllerConfiguration1.Object.DeviceName && scheme.SchemeName == "Scheme1");
+        Assert.Contains(definition.InputSchemes, scheme => scheme.DeviceName == _mockControllerConfiguration1.Object.DeviceName && scheme.SchemeName == "Scheme2");
+        Assert.Contains(definition.InputSchemes, scheme => scheme.DeviceName == _mockControllerConfiguration2.Object.DeviceName && scheme.SchemeName == "Scheme1");
     }
 
     #endregion

--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputManagerTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputManagerTests.cs
@@ -39,7 +39,7 @@ public class InputManagerTests
         _mockControllerConfiguration = new();
         _mockControllerConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
-        _mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        _mockControllerConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("TestController"));
 
         _mockControllerConfiguration.SetupGet(m => m.Inputs)
@@ -104,7 +104,7 @@ public class InputManagerTests
         var testDefinition2 = _4UserManagerWithCustomSchemes.Configuration.InputDefinitions.Last();
 
         var customScheme = new InputScheme(testDefinition.Name,
-            _4UserManagerWithCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName,
+            _4UserManagerWithCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName,
             "custom", false, []);
 
         _mockInputSchemeRepository.Setup(m => m.GetCustomInputSchemesAsync(It.Is<string>(name => name == testDefinition.Name),
@@ -308,13 +308,13 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, "notreal", controller.ControllerName, inputDefinition.InputSchemes.First().SchemeName);
+        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, "notreal", device.DeviceName, inputDefinition.InputSchemes.First().SchemeName);
 
         // Assert
         Assert.False(result.IsSuccessful);
@@ -328,7 +328,7 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
@@ -348,13 +348,13 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName, "notreal");
+        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName, "notreal");
 
         // Assert
         Assert.False(result.IsSuccessful);
@@ -368,7 +368,7 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         _mockInputSchemeRepository.Setup(m => m.SaveActiveInputSchemeAsync(It.IsAny<ActiveInputScheme>(), It.IsAny<CancellationToken>()))
@@ -377,7 +377,7 @@ public class InputManagerTests
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName, inputDefinition.InputSchemes.First().SchemeName);
+        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName, inputDefinition.InputSchemes.First().SchemeName);
 
         // Assert
         Assert.False(result.IsSuccessful);
@@ -398,7 +398,7 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         var userJoined = await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
@@ -411,7 +411,7 @@ public class InputManagerTests
             .ReturnsAsync(_outputFactory.Fail<IEnumerable<ActiveInputScheme>>("Bad Day", OutputSpecificityCode.SpecificityNotRecognized));
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName, inputDefinition.InputSchemes.First().SchemeName);
+        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName, inputDefinition.InputSchemes.First().SchemeName);
 
         // Assert
         Assert.False(result.IsSuccessful);
@@ -432,7 +432,7 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.Last();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
@@ -443,7 +443,7 @@ public class InputManagerTests
             .ReturnsAsync((ActiveInputScheme scheme, CancellationToken _) => _outputFactory.Succeed(scheme));
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName, inputDefinition.InputSchemes.First().SchemeName);
+        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName, inputDefinition.InputSchemes.First().SchemeName);
 
         // Assert
         Assert.True(result.IsSuccessful);
@@ -460,7 +460,7 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.Last();
 
         ActiveInputScheme activeScheme = new ActiveInputScheme(1, "", "", "");
@@ -477,7 +477,7 @@ public class InputManagerTests
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName, inputDefinition.InputSchemes.First().SchemeName);
+        var result = await _2UserManagerWithNoCustomSchemes.SetActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName, inputDefinition.InputSchemes.First().SchemeName);
 
         // Assert
         Assert.True(result.IsSuccessful);
@@ -516,13 +516,13 @@ public class InputManagerTests
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Fail("A bad day", OutputSpecificityCode.DataTooLarge));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName);
+        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName);
 
         // Assert
         Assert.False(result.IsSuccessful);
@@ -547,7 +547,7 @@ public class InputManagerTests
             It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed());
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
@@ -556,7 +556,7 @@ public class InputManagerTests
             .ReturnsAsync(_outputFactory.Fail<IEnumerable<ActiveInputScheme>>("a bad day", OutputSpecificityCode.DataTooLarge));
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName);
+        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName);
 
         // Assert
         Assert.False(result.IsSuccessful);
@@ -577,7 +577,7 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.Last();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
@@ -589,7 +589,7 @@ public class InputManagerTests
             .ReturnsAsync(_outputFactory.Succeed());
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName);
+        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName);
 
         // Assert
         Assert.True(result.IsSuccessful);
@@ -607,13 +607,13 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
         var inputDefinition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
 
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
 
         // Act
-        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, controller.ControllerName);
+        var result = await _2UserManagerWithNoCustomSchemes.ResetUserActiveInputSchemeAsync(1, inputDefinition.Name, device.DeviceName);
 
         // Assert
         Assert.True(result.IsSuccessful);
@@ -664,8 +664,8 @@ public class InputManagerTests
     {
         // Arrange
         var definition = _4UserManagerWithCustomSchemes.Configuration.InputDefinitions.First();
-        var controller = _4UserManagerWithCustomSchemes.Configuration.SupportedInputControllers.First();
-        var scheme = new InputScheme(definition.Name, controller.ControllerName, "abc", false, []);
+        var device = _4UserManagerWithCustomSchemes.Configuration.SupportedInputDevices.First();
+        var scheme = new InputScheme(definition.Name, device.DeviceName, "abc", false, []);
 
         var validationContext = new InputValidationContext("test");
         validationContext.AddErrors(1, "Oh ya");
@@ -743,7 +743,7 @@ public class InputManagerTests
     {
         // Arrange
         var definitionName = _4UserManagerWithCustomSchemes.Configuration.InputDefinitions.First().Name;
-        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName;
+        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName;
         var schemeName = _4UserManagerWithCustomSchemes.Configuration.InputDefinitions.First().InputSchemes.First().SchemeName;
 
         // Act
@@ -781,7 +781,7 @@ public class InputManagerTests
     {
         // Arrange
         var definitionName = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First().Name;
-        var deviceName = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName;
+        var deviceName = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName;
 
         // Act
         var deleteOutput = await _2UserManagerWithNoCustomSchemes.DeleteCustomInputSchemeAsync(definitionName, deviceName, deviceName.Name);
@@ -795,7 +795,7 @@ public class InputManagerTests
     {
         // Arrange
         var definitionName = _4UserManagerWithCustomSchemes.Configuration.InputDefinitions.First().Name;
-        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName;
+        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName;
         var schemeName = _4UserManagerWithCustomSchemes.Configuration.InputDefinitions.First().InputSchemes.First().SchemeName;
 
         _mockInputSchemeRepository.Setup(m => m.DeleteCustomInputSchemeAsync(It.IsAny<string>(), It.IsAny<InputDeviceName>(), It.IsAny<string>(),
@@ -844,7 +844,7 @@ public class InputManagerTests
     {
         // Arrange
         var definition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
 
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed((IEnumerable<ActiveInputScheme>)[]));
@@ -852,7 +852,7 @@ public class InputManagerTests
         // Act/Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() => _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, new JoinUserOptions()
         {
-            ControllerIdentifiers = [new InputDeviceIdentifier(1, new InputDeviceName("notreal"))]
+            DeviceIdentifiers = [new InputDeviceIdentifier(1, new InputDeviceName("notreal"))]
         }));
     }
 
@@ -904,7 +904,7 @@ public class InputManagerTests
         var result = await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, new JoinUserOptions()
         {
             ActiveInputDefinitionName = definition.Name,
-            ControllerIdentifiers =[ new InputDeviceIdentifier(1, _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName) ]
+            DeviceIdentifiers =[ new InputDeviceIdentifier(1, _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName) ]
         });
 
         // Assert
@@ -917,7 +917,7 @@ public class InputManagerTests
     {
         // Arrange
         var definition = _2UserManagerWithNoCustomSchemes.Configuration.InputDefinitions.First();
-        var controller = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputControllers.First();
+        var device = _2UserManagerWithNoCustomSchemes.Configuration.SupportedInputDevices.First();
 
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed((IEnumerable<ActiveInputScheme>)[]));
@@ -928,7 +928,7 @@ public class InputManagerTests
         var joinUserOutput2 = await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, new JoinUserOptions()
         {
             ActiveInputDefinitionName = "Bad",
-            ControllerIdentifiers = [new InputDeviceIdentifier(1, new InputDeviceName("Bad"))]
+            DeviceIdentifiers = [new InputDeviceIdentifier(1, new InputDeviceName("Bad"))]
         });
 
         // Assert
@@ -1002,16 +1002,16 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName;
-        var controllerIndentifier = new InputDeviceIdentifier(1, deviceName);
+        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName;
+        var deviceIdentifier = new InputDeviceIdentifier(1, deviceName);
 
         await _4UserManagerWithCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
         await _4UserManagerWithCustomSchemes.JoinUserAsync(2, JoinUserOptions.Default);
 
-        _4UserManagerWithCustomSchemes.PairController(1, controllerIndentifier);
+        _4UserManagerWithCustomSchemes.PairController(1, deviceIdentifier);
 
         // Act/Assert
-        Assert.Throws<InvalidOperationException>(() => _4UserManagerWithCustomSchemes.PairController(2, controllerIndentifier));
+        Assert.Throws<InvalidOperationException>(() => _4UserManagerWithCustomSchemes.PairController(2, deviceIdentifier));
     }
 
     [Fact]
@@ -1028,16 +1028,16 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName;
-        var controllerIndentifier = new InputDeviceIdentifier(1, deviceName);
+        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName;
+        var deviceIdentifier = new InputDeviceIdentifier(1, deviceName);
 
         var user = await _4UserManagerWithCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
 
         // Act
-        _4UserManagerWithCustomSchemes.PairController(1, controllerIndentifier);
+        _4UserManagerWithCustomSchemes.PairController(1, deviceIdentifier);
 
         // Assert
-        Assert.Single(user.Value.ControllerIdentifiers, identifier => identifier == controllerIndentifier);
+        Assert.Single(user.Value.DeviceIdentifiers, identifier => identifier == deviceIdentifier);
     }
 
     [Fact]
@@ -1054,17 +1054,17 @@ public class InputManagerTests
         _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
 
-        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputControllers.First().ControllerName;
-        var controllerIndentifier = new InputDeviceIdentifier(1, deviceName);
+        var deviceName = _4UserManagerWithCustomSchemes.Configuration.SupportedInputDevices.First().DeviceName;
+        var deviceIdentifier = new InputDeviceIdentifier(1, deviceName);
 
         var user = await _4UserManagerWithCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
-        _4UserManagerWithCustomSchemes.PairController(1, controllerIndentifier);
+        _4UserManagerWithCustomSchemes.PairController(1, deviceIdentifier);
 
         // Act
-        _4UserManagerWithCustomSchemes.PairController(1, controllerIndentifier);
+        _4UserManagerWithCustomSchemes.PairController(1, deviceIdentifier);
 
         // Assert
-        Assert.Single(user.Value.ControllerIdentifiers, identifier => identifier == controllerIndentifier);
+        Assert.Single(user.Value.DeviceIdentifiers, identifier => identifier == deviceIdentifier);
     }
 
     #endregion

--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputSchemeBuilderTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputSchemeBuilderTests.cs
@@ -26,7 +26,7 @@ public class InputSchemeBuilderTests
     public InputSchemeBuilderTests()
     {
         _mockControllerConfiguration = new();
-        _mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        _mockControllerConfiguration.SetupGet(m => m.DeviceName)
             .Returns(ControllerName);
 
         _builder = new(DefinitionName, _mockControllerConfiguration.Object, SchemeName);

--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputSystemBuilderTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputSystemBuilderTests.cs
@@ -92,7 +92,7 @@ public class InputSystemBuilderTests
     {
         // Arrange
         var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m =>  m.ControllerName)
+        mockControllerConfiguration.SetupGet(m =>  m.DeviceName)
             .Returns(new InputDeviceName(deviceName));
         
         // Act/Assert
@@ -104,7 +104,7 @@ public class InputSystemBuilderTests
     {
         // Arrange
         var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        mockControllerConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
 
         _builder.AddInputController(mockControllerConfiguration.Object);
@@ -118,7 +118,7 @@ public class InputSystemBuilderTests
     {
         // Arrange
         var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        mockControllerConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
 
         //Act/Assert
@@ -208,7 +208,7 @@ public class InputSystemBuilderTests
             .Returns(InputValidationContext.Success);
 
         var mockInputController = new Mock<IInputDeviceConfiguration>();
-        mockInputController.SetupGet(m => m.ControllerName)
+        mockInputController.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
 
         _builder
@@ -228,8 +228,8 @@ public class InputSystemBuilderTests
         Assert.Single(inputSystemConfiguration.InputDefinitions);
         Assert.Equal(definition, inputSystemConfiguration.InputDefinitions.ElementAt(0));
 
-        Assert.Single(inputSystemConfiguration.SupportedInputControllers);
-        Assert.Equal(mockInputController.Object, inputSystemConfiguration.SupportedInputControllers.ElementAt(0));
+        Assert.Single(inputSystemConfiguration.SupportedInputDevices);
+        Assert.Equal(mockInputController.Object, inputSystemConfiguration.SupportedInputDevices.ElementAt(0));
 
         Assert.Equal(12, inputSystemConfiguration.MaxLocalUsers);
         Assert.True(inputSystemConfiguration.AllowCustomInputSchemes);

--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputValidationServiceTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputValidationServiceTests.cs
@@ -36,19 +36,19 @@ public class InputValidationServiceTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void ValidateInputSystemConfiguration_EmptyControllerConfiguration_ReturnsInputControllerMissingDataError(bool useNull)
+    public void ValidateInputSystemConfiguration_EmptyDeviceConfiguration_ReturnsInputDeviceMissingDataError(bool useNull)
     {
         // Arrange
         List<InputDefinition> definitions = [];
-        List<IInputDeviceConfiguration>? controllerConfigurations = useNull ? null : [];
+        List<IInputDeviceConfiguration>? deviceConfigurations = useNull ? null : [];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations!, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations!, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
 
         // Assert
-        Assert.Equal(InputValidationService.InputControllerError, validationContext.ErrorCategory);
+        Assert.Equal(InputValidationService.InputDeviceError, validationContext.ErrorCategory);
         Assert.True(validationContext.CheckErrorExists(InputValidationService.ValidationError_CollectionMissingData));
     }
 
@@ -56,106 +56,106 @@ public class InputValidationServiceTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("  ")]
-    public void ValidateInputSystemConfiguration_InvalidControllerConfigurationNames_ReturnsInputControllerMissingIdentifierError(string? deviceName)
+    public void ValidateInputSystemConfiguration_InvalidDeviceConfigurationNames_ReturnsInputDeviceMissingIdentifierError(string? deviceName)
     {
         // Arrange
         List<InputDefinition> definitions = [];
 
-        var mockControllerConfiguration1 = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration1 = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName(deviceName));
 
-        List<IInputDeviceConfiguration>? controllerConfigurations = [ mockControllerConfiguration1.Object ];
+        List<IInputDeviceConfiguration>? deviceConfigurations = [ mockDeviceConfiguration1.Object ];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
 
         // Assert
-        Assert.Equal(InputValidationService.InputControllerError, validationContext.ErrorCategory);
+        Assert.Equal(InputValidationService.InputDeviceError, validationContext.ErrorCategory);
         Assert.True(validationContext.CheckErrorExists(InputValidationService.ValidationError_MissingIdentifier));
     }
 
     [Fact]
-    public void ValidateInputSystemConfiguration_DuplicateControllerConfigurationNames_ReturnsInputControllerDuplicateIdentifierError()
+    public void ValidateInputSystemConfiguration_DuplicateDeviceConfigurationNames_ReturnsInputDeviceDuplicateIdentifierError()
     {
         // Arrange
         List<InputDefinition> definitions = [];
 
-        var mockControllerConfiguration1 = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration1 = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("default"));
 
-        var mockControllerConfiguration2 = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration2.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration2 = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration2.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("default"));
 
-        List<IInputDeviceConfiguration>? controllerConfigurations = [mockControllerConfiguration1.Object, mockControllerConfiguration2.Object];
+        List<IInputDeviceConfiguration>? deviceConfigurations = [mockDeviceConfiguration1.Object, mockDeviceConfiguration2.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
 
         // Assert
-        Assert.Equal(InputValidationService.InputControllerError, validationContext.ErrorCategory);
+        Assert.Equal(InputValidationService.InputDeviceError, validationContext.ErrorCategory);
         Assert.True(validationContext.CheckErrorExists(InputValidationService.ValidationError_DuplicateIdentifier));
     }
 
     [Theory]
     [InlineData(null)]
     [InlineData(typeof(int))]
-    public void ValidateInputSystemConfiguration_InvalidControllerConfigurationInputReaderType_ReturnsInputControllerInvalidDataError(Type? type)
+    public void ValidateInputSystemConfiguration_InvalidDeviceConfigurationInputReaderType_ReturnsInputDeviceInvalidDataError(Type? type)
     {
         // Arrange
         List<InputDefinition> definitions = [];
 
-        var mockControllerConfiguration1 = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration1 = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("default"));
-        mockControllerConfiguration1.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration1.SetupGet(m => m.InputReaderType)
             .Returns(type!);
 
-        List<IInputDeviceConfiguration>? controllerConfigurations = [mockControllerConfiguration1.Object];
+        List<IInputDeviceConfiguration>? deviceConfigurations = [mockDeviceConfiguration1.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
 
         // Assert
-        Assert.Equal(InputValidationService.InputControllerError, validationContext.ErrorCategory);
+        Assert.Equal(InputValidationService.InputDeviceError, validationContext.ErrorCategory);
         Assert.True(validationContext.CheckErrorExists(InputValidationService.ValidationError_InvalidData));
     }
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void ValidateInputSystemConfiguration_ControllerConfigurationEmptyInputs_ReturnsInputControllerMissingDataError(bool useNull)
+    public void ValidateInputSystemConfiguration_DeviceConfigurationEmptyInputs_ReturnsInputDeviceMissingDataError(bool useNull)
     {
         // Arrange
         List<InputDefinition> definitions = [];
 
-        var mockControllerConfiguration1 = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration1 = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("default"));
 
-        mockControllerConfiguration1.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration1.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
-        mockControllerConfiguration1.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration1.SetupGet(m => m.Inputs)
             .Returns(useNull ? null! : []);
 
-        List<IInputDeviceConfiguration>? controllerConfigurations = [mockControllerConfiguration1.Object];
+        List<IInputDeviceConfiguration>? deviceConfigurations = [mockDeviceConfiguration1.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
 
         // Assert
-        Assert.Equal(InputValidationService.InputControllerError, validationContext.ErrorCategory);
+        Assert.Equal(InputValidationService.InputDeviceError, validationContext.ErrorCategory);
         Assert.True(validationContext.CheckErrorExists(InputValidationService.ValidationError_CollectionMissingData));
     }
 
@@ -163,33 +163,33 @@ public class InputValidationServiceTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("  ")]
-    public void ValidateInputSystemConfiguration_ControllerConfigurationInvalidInputNames_ReturnsInputControllerInvalidDataError(string? inputName)
+    public void ValidateInputSystemConfiguration_DeviceConfigurationInvalidInputNames_ReturnsInputDeviceInvalidDataError(string? inputName)
     {
         // Arrange
         List<InputDefinition> definitions = [];
 
-        var mockControllerConfiguration1 = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration1.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration1 = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration1.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("default"));
-        mockControllerConfiguration1.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration1.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns(inputName!);
 
-        mockControllerConfiguration1.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration1.SetupGet(m => m.Inputs)
             .Returns([ mockInput.Object ]);
 
-        List<IInputDeviceConfiguration>? controllerConfigurations = [mockControllerConfiguration1.Object];
+        List<IInputDeviceConfiguration>? deviceConfigurations = [mockDeviceConfiguration1.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
 
         // Assert
-        Assert.Equal(InputValidationService.InputControllerError, validationContext.ErrorCategory);
+        Assert.Equal(InputValidationService.InputDeviceError, validationContext.ErrorCategory);
         Assert.True(validationContext.CheckErrorExists(InputValidationService.ValidationError_InvalidData));
     }
 
@@ -201,21 +201,21 @@ public class InputValidationServiceTests
         // Arrange
         List<InputDefinition>? definitions = useNull ? null : [];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
         
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions!, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions!, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -234,21 +234,21 @@ public class InputValidationServiceTests
         // Arrange
         List<InputDefinition> definitions = [new InputDefinition(definitionName!, [], [])];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -264,21 +264,21 @@ public class InputValidationServiceTests
         // Arrange
         List<InputDefinition> definitions = [new InputDefinition("abc", [], []), new InputDefinition("abc", [], [])];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act  
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -294,21 +294,21 @@ public class InputValidationServiceTests
         // Arrange
         List<InputDefinition> definitions = [new InputDefinition("abc", [], [])];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -326,21 +326,21 @@ public class InputValidationServiceTests
         // Arrange
         List<InputDefinition> definitions = [new InputDefinition("abc", [new InputAction(inputActionKey!, _ => ValueTask.CompletedTask, null)], [])];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -360,21 +360,21 @@ public class InputValidationServiceTests
                 ], [])
             ];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -396,21 +396,21 @@ public class InputValidationServiceTests
                 [ new InputScheme("abc", "abc", "abc", false, [ new InputActionMap("a", 1, InputPhase.Start) ]) ])
          ];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, maxLocalusers);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, maxLocalusers);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -430,21 +430,21 @@ public class InputValidationServiceTests
                 [ new InputScheme("abc", "abc", "abc", false, [ new InputActionMap("a", 1, InputPhase.Start) ]) ])
          ];
 
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
             .Returns(new InputDeviceName("abc"));
-        mockControllerConfiguration.SetupGet(m => m.InputReaderType)
+        mockDeviceConfiguration.SetupGet(m => m.InputReaderType)
             .Returns(typeof(TestInputReader));
 
         var mockInput = new Mock<IInput>();
         mockInput.SetupGet(m => m.Name)
             .Returns("abc");
-        mockControllerConfiguration.SetupGet(m => m.Inputs)
+        mockDeviceConfiguration.SetupGet(m => m.Inputs)
             .Returns([mockInput.Object]);
 
-        List<IInputDeviceConfiguration> controllerConfigurations = [mockControllerConfiguration.Object];
+        List<IInputDeviceConfiguration> deviceConfigurations = [mockDeviceConfiguration.Object];
 
-        var inputSystemConfiguration = new InputSystemConfiguration(definitions, controllerConfigurations, false, 1);
+        var inputSystemConfiguration = new InputSystemConfiguration(definitions, deviceConfigurations, false, 1);
 
         // Act
         var validationContext = _service.ValidateInputSystemConfiguration(inputSystemConfiguration);
@@ -518,7 +518,7 @@ public class InputValidationServiceTests
         // Arrange/Act
         var validationContext = _service.ValidateCustomInputScheme(
             new InputSystemConfiguration([new InputDefinition("abc", [], [])], [], false, 2),
-            new InputScheme("abc", "controller", "abc", false, []));
+            new InputScheme("abc", "device", "abc", false, []));
 
         // Assert
         Assert.Equal(InputValidationService.InputSchemeError, validationContext.ErrorCategory);
@@ -532,14 +532,14 @@ public class InputValidationServiceTests
     public void ValidateCustomInputScheme_InputSchemeInvalidSchemeName_AddsMissingIdentifierErrorToContext(string? schemeName)
     {
         // Arrange
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("controller"));
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("device"));
 
         // Act
         var validationContext = _service.ValidateCustomInputScheme(
-            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [ mockControllerConfiguration.Object ], false, 2),
-            new InputScheme("abc", mockControllerConfiguration.Object.ControllerName.Name, schemeName!, false, []));
+            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [ mockDeviceConfiguration.Object ], false, 2),
+            new InputScheme("abc", mockDeviceConfiguration.Object.DeviceName.Name, schemeName!, false, []));
 
         // Assert
         Assert.Equal(InputValidationService.InputSchemeError, validationContext.ErrorCategory);
@@ -553,14 +553,14 @@ public class InputValidationServiceTests
     public void ValidateCustomInputScheme_DuplicateInputSchemeName_AddsDuplicateIdentifierErrorToContext(string schemeName1, string schemeName2)
     {
         // Arrange
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("controller"));
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("device"));
 
         // Act
         var validationContext = _service.ValidateCustomInputScheme(
-            new InputSystemConfiguration([new InputDefinition("abc", [], [ new InputScheme("abc", "controller", schemeName1, false, []) ])], [ mockControllerConfiguration.Object ], false, 2),
-            new InputScheme("abc", "controller", schemeName2, false, []));
+            new InputSystemConfiguration([new InputDefinition("abc", [], [ new InputScheme("abc", "device", schemeName1, false, []) ])], [ mockDeviceConfiguration.Object ], false, 2),
+            new InputScheme("abc", "device", schemeName2, false, []));
 
         // Assert
         Assert.Equal(InputValidationService.InputSchemeError, validationContext.ErrorCategory);
@@ -568,17 +568,17 @@ public class InputValidationServiceTests
     }
 
     [Fact]
-    public void ValidateCustomInputScheme_DuplicateInputControllerConfigurationActionMapInputKey_AddsInvalidDataErrorToContext()
+    public void ValidateCustomInputScheme_DuplicateInputDeviceConfigurationActionMapInputKey_AddsInvalidDataErrorToContext()
     {
         // Arrange
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("controller"));
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("device"));
 
         // Act
         var validationContext = _service.ValidateCustomInputScheme(
-            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [mockControllerConfiguration.Object], false, 2),
-            new InputScheme("abc", "controller", "abc", false, [
+            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [mockDeviceConfiguration.Object], false, 2),
+            new InputScheme("abc", "device", "abc", false, [
                     new InputActionMap("actionKey", 1, InputPhase.Start),
                     new InputActionMap("actionKey2", 1, InputPhase.Start)
              ]));
@@ -592,17 +592,17 @@ public class InputValidationServiceTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public void ValidateCustomInputScheme_InvalidInputControllerConfigurationActionMapActionKey_AddsInvalidDataErrorToContext(string? actionKey)
+    public void ValidateCustomInputScheme_InvalidInputDeviceConfigurationActionMapActionKey_AddsInvalidDataErrorToContext(string? actionKey)
     {
         // Arrange
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("controller"));
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("device"));
 
         // Act
         var validationContext = _service.ValidateCustomInputScheme(
-            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [mockControllerConfiguration.Object], false, 2),
-            new InputScheme("abc", "controller", "abc", false, [new InputActionMap(actionKey!, 1, InputPhase.Start)]));
+            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [mockDeviceConfiguration.Object], false, 2),
+            new InputScheme("abc", "device", "abc", false, [new InputActionMap(actionKey!, 1, InputPhase.Start)]));
 
         // Assert
         Assert.Equal(InputValidationService.InputActionMapError, validationContext.ErrorCategory);
@@ -613,17 +613,17 @@ public class InputValidationServiceTests
     [InlineData("aBcD", "abcd")]
     [InlineData("efgh", "efgh")]
     [InlineData("IJKL", "IJKL")]
-    public void ValidateCustomInputScheme_DuplicateInputControllerConfigurationActionMapActionKey_AddsInvalidDataErrorToContext(string actionKey1, string actionKey2)
+    public void ValidateCustomInputScheme_DuplicateInputDeviceConfigurationActionMapActionKey_AddsInvalidDataErrorToContext(string actionKey1, string actionKey2)
     {        
         // Arrange
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("controller"));
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("device"));
 
         // Act
         var validationContext = _service.ValidateCustomInputScheme(
-            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [mockControllerConfiguration.Object], false, 2),
-            new InputScheme("abc", "controller", "abc", false, [
+            new InputSystemConfiguration([new InputDefinition("abc", [], [])], [mockDeviceConfiguration.Object], false, 2),
+            new InputScheme("abc", "device", "abc", false, [
                     new InputActionMap(actionKey1, 1, InputPhase.Start),
                     new InputActionMap(actionKey2, 2, InputPhase.Start)
              ]));
@@ -637,9 +637,9 @@ public class InputValidationServiceTests
     public void ValidateCustomInputScheme_SchemeMissingActionKeysInDefinition_AddsMissingDataErrorToContext()
     {
         // Arrange
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("controller"));
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("device"));
 
         // Act
         var validationContext = _service.ValidateCustomInputScheme(
@@ -649,8 +649,8 @@ public class InputValidationServiceTests
                     new InputAction("abc", _ => ValueTask.CompletedTask, null), 
                     new InputAction("def", _ => ValueTask.CompletedTask, null)
                 ], [])], 
-                [mockControllerConfiguration.Object], false, 2),
-            new InputScheme("abc", "controller", "abc", false, [new InputActionMap("abc", 1, InputPhase.Start)]));
+                [mockDeviceConfiguration.Object], false, 2),
+            new InputScheme("abc", "device", "abc", false, [new InputActionMap("abc", 1, InputPhase.Start)]));
 
         // Assert
         Assert.Equal(InputValidationService.InputSchemeError, validationContext.ErrorCategory);
@@ -661,9 +661,9 @@ public class InputValidationServiceTests
     public void ValidateCustomInputScheme_Valid_ReturnsSuccessfully()
     {
         // Arrange
-        var mockControllerConfiguration = new Mock<IInputDeviceConfiguration>();
-        mockControllerConfiguration.SetupGet(m => m.ControllerName)
-            .Returns(new InputDeviceName("controller"));
+        var mockDeviceConfiguration = new Mock<IInputDeviceConfiguration>();
+        mockDeviceConfiguration.SetupGet(m => m.DeviceName)
+            .Returns(new InputDeviceName("device"));
 
         // Act
         var validationContext = _service.ValidateCustomInputScheme(
@@ -672,8 +672,8 @@ public class InputValidationServiceTests
                 new InputAction("abc", _ => ValueTask.CompletedTask, null), 
                 new InputAction("def", _ => ValueTask.CompletedTask, null)], 
                 [])],
-                [mockControllerConfiguration.Object], false, 2),
-            new InputScheme("abc", "controller", "abc", false, 
+                [mockDeviceConfiguration.Object], false, 2),
+            new InputScheme("abc", "device", "abc", false, 
             [ new InputActionMap("abc", 1, InputPhase.Start), new InputActionMap("def", 2, InputPhase.Start)]));
 
         // Assert

--- a/src/OSK.Inputs.UnitTests/_Helpers/TestInputReader.cs
+++ b/src/OSK.Inputs.UnitTests/_Helpers/TestInputReader.cs
@@ -6,7 +6,7 @@ using OSK.Inputs.Ports;
 namespace OSK.Inputs.UnitTests._Helpers;
 public class TestInputReader(InputReaderParameters parameters) : IInputReader
 {
-    public InputDeviceIdentifier ControllerIdentifier => parameters.ControllerIdentifier;
+    public InputDeviceIdentifier ControllerIdentifier => parameters.DeviceIdentifier;
     public IEnumerable<IInput> Inputs => parameters.Inputs;
 
     public event Action<InputDeviceIdentifier> OnControllerDisconnected = _ => { };

--- a/src/OSK.Inputs/InputDefinitionBuilderExtensions.cs
+++ b/src/OSK.Inputs/InputDefinitionBuilderExtensions.cs
@@ -11,9 +11,11 @@ namespace OSK.Inputs;
 
 public static class InputDefinitionBuilderExtensions
 {
-    public static IInputDefinitionBuilder AddAction<TService>(this IInputDefinitionBuilder builder, string actionName, 
-        Func<TService, InputActivationEvent, ValueTask> actionExecutor)
-        where TService: notnull
+    #region Actions
+
+    public static IInputDefinitionBuilder AddAction<TService>(this IInputDefinitionBuilder builder, string actionName,
+    Func<TService, InputActivationEvent, ValueTask> actionExecutor)
+    where TService : notnull
         => builder.AddAction(actionName, null, @event => actionExecutor(@event.Services.GetRequiredService<TService>(), @event));
 
     public static IInputDefinitionBuilder AddAction<TService>(this IInputDefinitionBuilder builder, string actionName,
@@ -21,11 +23,11 @@ public static class InputDefinitionBuilderExtensions
         where TService : notnull
         => builder.AddAction(actionName, description, @event => actionExecutor(@event.Services.GetRequiredService<TService>(), @event));
 
-    public static IInputDefinitionBuilder AddAction(this IInputDefinitionBuilder builder, string actionName, 
+    public static IInputDefinitionBuilder AddAction(this IInputDefinitionBuilder builder, string actionName,
         Func<InputActivationEvent, ValueTask> actionExecutor)
         => builder.AddAction(actionName, null, actionExecutor);
 
-    public static IInputDefinitionBuilder AddAction(this IInputDefinitionBuilder builder, string actionName, string? description, 
+    public static IInputDefinitionBuilder AddAction(this IInputDefinitionBuilder builder, string actionName, string? description,
         Func<InputActivationEvent, ValueTask> actionExecutor)
     {
         if (actionExecutor is null)
@@ -36,4 +38,71 @@ public static class InputDefinitionBuilderExtensions
         builder.AddAction(new InputAction(actionName, actionExecutor, description));
         return builder;
     }
+
+    #endregion
+
+    #region Input Schemes
+
+    public static IInputDefinitionBuilder AddInputScheme(this IInputDefinitionBuilder builder, InputDeviceName deviceName,
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(deviceName, InputScheme.DefaultSchemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddKeyboardScheme(this IInputDefinitionBuilder builder, 
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(Keyboard.KeyboardName, InputScheme.DefaultSchemeName, schemeConfigurator);
+    }
+    public static IInputDefinitionBuilder AddKeyboardScheme(this IInputDefinitionBuilder builder, string schemeName,
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(Keyboard.KeyboardName, schemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddMouseScheme(this IInputDefinitionBuilder builder, Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(Mouse.MouseName, InputScheme.DefaultSchemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddMouseScheme(this IInputDefinitionBuilder builder, string schemeName,
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(Mouse.MouseName, schemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddXboxScheme(this IInputDefinitionBuilder builder, 
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(XboxController.XboxControllerName, InputScheme.DefaultSchemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddXboxScheme(this IInputDefinitionBuilder builder, string schemeName,
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(XboxController.XboxControllerName, schemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddPlayStationScheme(this IInputDefinitionBuilder builder, Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(PlayStationController.PlayStationControllerName, InputScheme.DefaultSchemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddPlayStationScheme(this IInputDefinitionBuilder builder, string schemeName,
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(PlayStationController.PlayStationControllerName, schemeName, schemeConfigurator);
+    }
+
+    public static IInputDefinitionBuilder AddSensorScheme(this IInputDefinitionBuilder builder, Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(SensorController.SensorControllerName, InputScheme.DefaultSchemeName, schemeConfigurator);
+    }
+    public static IInputDefinitionBuilder AddSensorScheme(this IInputDefinitionBuilder builder, string schemeName,
+        Action<IInputSchemeBuilder> schemeConfigurator)
+    {
+        return builder.AddInputScheme(SensorController.SensorControllerName, schemeName, schemeConfigurator);
+    }
+
+    #endregion
 }

--- a/src/OSK.Inputs/InputSystemBuilderExtensions.cs
+++ b/src/OSK.Inputs/InputSystemBuilderExtensions.cs
@@ -9,16 +9,16 @@ public static class InputSystemBuilderExtensions
 {
     #region Public
 
-    public static IInputSystemBuilder AddXboxController<TInputReader>(this IInputSystemBuilder builder, Action<XboxControllerDevice> configurator)
+    public static IInputSystemBuilder AddXboxController<TInputReader>(this IInputSystemBuilder builder, Action<XboxController> configurator)
         where TInputReader : IInputReader
     {
-        return builder.AddInputDevice<XboxControllerDevice, TInputReader>(configurator);
+        return builder.AddInputDevice<XboxController, TInputReader>(configurator);
     }
 
-    public static IInputSystemBuilder AddPlayStationController<TInputReader>(this IInputSystemBuilder builder, Action<PlayStationControllerDevice> configurator)
+    public static IInputSystemBuilder AddPlayStationController<TInputReader>(this IInputSystemBuilder builder, Action<PlayStationController> configurator)
         where TInputReader : IInputReader
     {
-        return builder.AddInputDevice<PlayStationControllerDevice, TInputReader>(configurator);
+        return builder.AddInputDevice<PlayStationController, TInputReader>(configurator);
     }
 
     public static IInputSystemBuilder AddKeyboard<TInputReader>(this IInputSystemBuilder builder, Action<Keyboard> configurator)
@@ -33,10 +33,10 @@ public static class InputSystemBuilderExtensions
         return builder.AddInputDevice<Mouse, TInputReader>(configurator);
     }
 
-    public static IInputSystemBuilder AddSensorController<TInputReader>(this IInputSystemBuilder builder, Action<SensorControllerDevice> configurator)
+    public static IInputSystemBuilder AddSensorController<TInputReader>(this IInputSystemBuilder builder, Action<SensorController> configurator)
         where TInputReader : IInputReader
     {
-        return builder.AddInputDevice<SensorControllerDevice, TInputReader>(configurator);
+        return builder.AddInputDevice<SensorController, TInputReader>(configurator);
     }
 
     #endregion

--- a/src/OSK.Inputs/Internal/DefaultInputDeviceConfiguration.cs
+++ b/src/OSK.Inputs/Internal/DefaultInputDeviceConfiguration.cs
@@ -12,25 +12,25 @@ internal class DefaultInputDeviceConfiguration(InputDeviceName deviceName, Type 
     private readonly Dictionary<int, IInput> _inputLookup = inputs?.ToDictionary(input => input.Id) ?? [];
 
     /// <summary>
-    /// Strongly typed controller name
+    /// Strongly typed device name
     /// </summary>
-    public InputDeviceName ControllerName => deviceName;
+    public InputDeviceName DeviceName => deviceName;
 
     /// <summary>
-    /// The type of object that is able process input from this controller. See <see cref="IInputReader"/>
+    /// The type of object that is able process input from this device. See <see cref="IInputReader"/>
     /// </summary>
     public Type InputReaderType => readerType;
 
     /// <summary>
-    /// The collection of <see cref="IInput"/>s associated to this controller
+    /// The collection of <see cref="IInput"/>s associated to this device
     /// </summary>
     public IReadOnlyCollection<IInput> Inputs { get; } = inputs?.ToArray() ?? [];
 
     /// <summary>
-    /// Used to validate input schemes that are associated with this controller
+    /// Used to validate input schemes that are associated with this device
     /// </summary>
     /// <param name="input">The input being added to a scheme</param>
-    /// <returns>Whether the input is valid for this controller</returns>
+    /// <returns>Whether the input is valid for this device</returns>
     public bool IsValidInput(IInput input) 
         => validator?.Invoke(input) 
         ?? _inputLookup.TryGetValue(input.Id, out var inputValue) && inputValue.DeviceType.Equals(input.DeviceType, StringComparison.Ordinal);

--- a/src/OSK.Inputs/Internal/Services/DefaultInputReaderProvider.cs
+++ b/src/OSK.Inputs/Internal/Services/DefaultInputReaderProvider.cs
@@ -9,15 +9,15 @@ internal class DefaultInputReaderProvider(IServiceProvider serviceProvider) : II
 {
     #region IInputReaderProvider
 
-    public IInputReader GetInputReader(IInputDeviceConfiguration controllerConfiguration, InputDeviceIdentifier controllerIdentifier)
+    public IInputReader GetInputReader(IInputDeviceConfiguration deviceConfiguration, InputDeviceIdentifier deviceIdentifier)
     {
-        if (controllerConfiguration is null)
+        if (deviceConfiguration is null)
         {
-            throw new ArgumentNullException(nameof(controllerConfiguration));
+            throw new ArgumentNullException(nameof(deviceConfiguration));
         }
 
-        return (IInputReader)ActivatorUtilities.CreateInstance(serviceProvider, controllerConfiguration.InputReaderType, 
-            new InputReaderParameters(controllerIdentifier, controllerConfiguration.Inputs));
+        return (IInputReader)ActivatorUtilities.CreateInstance(serviceProvider, deviceConfiguration.InputReaderType, 
+            new InputReaderParameters(deviceIdentifier, deviceConfiguration.Inputs));
     }
 
     #endregion

--- a/src/OSK.Inputs/Internal/Services/InMemoryInputSchemeRepository.cs
+++ b/src/OSK.Inputs/Internal/Services/InMemoryInputSchemeRepository.cs
@@ -22,8 +22,8 @@ internal class InMemoryInputSchemeRepository(IOutputFactory outputFactory) : IIn
 
     public Task<IOutput<IEnumerable<InputScheme>>> GetCustomInputSchemesAsync(string inputDefinitionName, CancellationToken cancellationToken = default)
     {
-        var customSchemes = _customInputSchemes.TryGetValue(inputDefinitionName, out var customControllerSchemeLookup)
-            ? customControllerSchemeLookup.Values.SelectMany(controllerSchemeGroupLookup => controllerSchemeGroupLookup.Values)
+        var customSchemes = _customInputSchemes.TryGetValue(inputDefinitionName, out var customDeviceSchemeLookup)
+            ? customDeviceSchemeLookup.Values.SelectMany(deviceSchemeGroupLookup => deviceSchemeGroupLookup.Values)
             : [];
         return Task.FromResult(outputFactory.Succeed(customSchemes));
     }
@@ -31,11 +31,11 @@ internal class InMemoryInputSchemeRepository(IOutputFactory outputFactory) : IIn
     public Task<IOutput<InputScheme>> GetCustomInputSchemeAsync(string inputDefinitionName, InputDeviceName deviceName,
         string inputSchemeName, CancellationToken cancellationToken = default)
     {
-        if (!_customInputSchemes.TryGetValue(inputDefinitionName, out var customControllerSchemeLookup))
+        if (!_customInputSchemes.TryGetValue(inputDefinitionName, out var customDeviceSchemeLookup))
         {
             return Task.FromResult(outputFactory.NotFound<InputScheme>($"No custom schemes were found for input definition {inputDefinitionName}"));
         }
-        if (!customControllerSchemeLookup.TryGetValue(deviceName.Name, out var customSchemeLookup))
+        if (!customDeviceSchemeLookup.TryGetValue(deviceName.Name, out var customSchemeLookup))
         {
             return Task.FromResult(outputFactory.NotFound<InputScheme>($"No custom schemes were found for the {deviceName} controller using the {inputDefinitionName} input defintiion"));
         }
@@ -52,15 +52,15 @@ internal class InMemoryInputSchemeRepository(IOutputFactory outputFactory) : IIn
             throw new ArgumentNullException(nameof(inputScheme));
         }
 
-        if (!_customInputSchemes.TryGetValue(inputDefinitionName, out var customControllerSchemeLookup))
+        if (!_customInputSchemes.TryGetValue(inputDefinitionName, out var customDeviceSchemeLookup))
         {
-            customControllerSchemeLookup = [];
-            _customInputSchemes[inputDefinitionName] = customControllerSchemeLookup;
+            customDeviceSchemeLookup = [];
+            _customInputSchemes[inputDefinitionName] = customDeviceSchemeLookup;
         }
-        if (!customControllerSchemeLookup.TryGetValue(inputScheme.ControllerName.Name, out var customSchemeLookup))
+        if (!customDeviceSchemeLookup.TryGetValue(inputScheme.DeviceName.Name, out var customSchemeLookup))
         {
             customSchemeLookup = [];
-            customControllerSchemeLookup[inputScheme.ControllerName.Name] = customSchemeLookup;
+            customDeviceSchemeLookup[inputScheme.DeviceName.Name] = customSchemeLookup;
         }
 
         customSchemeLookup[inputScheme.SchemeName] = inputScheme;
@@ -70,11 +70,11 @@ internal class InMemoryInputSchemeRepository(IOutputFactory outputFactory) : IIn
     public Task<IOutput> DeleteCustomInputSchemeAsync(string inputDefinitionName, InputDeviceName deviceName,
         string inputSchemeName, CancellationToken cancellationToken = default)
     {
-        if (!_customInputSchemes.TryGetValue(inputDefinitionName, out var customControllerSchemeLookup))
+        if (!_customInputSchemes.TryGetValue(inputDefinitionName, out var customDeviceSchemeLookup))
         {
             return Task.FromResult(outputFactory.Succeed());
         }
-        if (!customControllerSchemeLookup.TryGetValue(deviceName.Name, out var customSchemeLookup))
+        if (!customDeviceSchemeLookup.TryGetValue(deviceName.Name, out var customSchemeLookup))
         {
             return Task.FromResult(outputFactory.Succeed());
         }
@@ -87,9 +87,9 @@ internal class InMemoryInputSchemeRepository(IOutputFactory outputFactory) : IIn
     {
         var activeSchemes = Enumerable.Empty<ActiveInputScheme>();
         if (_activeSchemes.TryGetValue(userId, out var activeUserSchemes)
-             && activeUserSchemes.TryGetValue(inputDefinitionName, out var activeControllerSchemes))
+             && activeUserSchemes.TryGetValue(inputDefinitionName, out var activeDeviceSchemes))
         {
-            activeSchemes = activeControllerSchemes.Values;
+            activeSchemes = activeDeviceSchemes.Values;
         }
 
         return Task.FromResult(outputFactory.Succeed(activeSchemes));
@@ -113,7 +113,7 @@ internal class InMemoryInputSchemeRepository(IOutputFactory outputFactory) : IIn
             activeUserSchemes.Add(inputScheme.InputDefinitionName, activeSchemes);
         }
 
-        activeSchemes[inputScheme.ControllerName] = inputScheme;
+        activeSchemes[inputScheme.DeviceName] = inputScheme;
         return Task.FromResult(outputFactory.Succeed(inputScheme));
     }
 

--- a/src/OSK.Inputs/Internal/Services/InputSchemeBuilder.cs
+++ b/src/OSK.Inputs/Internal/Services/InputSchemeBuilder.cs
@@ -8,7 +8,7 @@ using OSK.Inputs.Ports;
 
 namespace OSK.Inputs.Internal.Services;
 
-internal class InputSchemeBuilder(string inputDefinitionName, IInputDeviceConfiguration controllerConfiguration, string schemeName) 
+internal class InputSchemeBuilder(string inputDefinitionName, IInputDeviceConfiguration deviceConfiguration, string schemeName) 
     : IInputSchemeBuilder
 {
     #region Variables
@@ -38,16 +38,16 @@ internal class InputSchemeBuilder(string inputDefinitionName, IInputDeviceConfig
                 {
                     if (group.Count() > 1)
                     {
-                        return (Exception) new DuplicateNameException($"The input {group.Key} has already been added to the combination input {combinationInput.Name} for the input controller {controllerConfiguration.ControllerName}");
+                        return (Exception) new DuplicateNameException($"The input {group.Key} has already been added to the combination input {combinationInput.Name} for the input controller {deviceConfiguration.DeviceName}");
                     }
 
-                    return controllerConfiguration.IsValidInput(group.First())
+                    return deviceConfiguration.IsValidInput(group.First())
                         ? null
-                        : new InvalidOperationException($"Unable to add inputs of type {combinationInput.GetType().FullName} to the combonation input {combinationInput.Name} for the input controller {controllerConfiguration.ControllerName} since it is not the expected input type.");
+                        : new InvalidOperationException($"Unable to add inputs of type {combinationInput.GetType().FullName} to the combonation input {combinationInput.Name} for the input controller {deviceConfiguration.DeviceName} since it is not the expected input type.");
                 }).FirstOrDefault(exceptionError => exceptionError is not null),
-            _ => controllerConfiguration.IsValidInput(input)
+            _ => deviceConfiguration.IsValidInput(input)
                 ? null
-                : new InvalidOperationException($"Unable to add inputs of type {input.GetType().FullName} for the input controller {controllerConfiguration.ControllerName} since it is not the expected input type.")
+                : new InvalidOperationException($"Unable to add inputs of type {input.GetType().FullName} for the input controller {deviceConfiguration.DeviceName} since it is not the expected input type.")
         };
 
         if (exception is not null) 
@@ -58,7 +58,7 @@ internal class InputSchemeBuilder(string inputDefinitionName, IInputDeviceConfig
         var actionLookupKey = $"{actionKey}.{inputPhase}";
         if (_inputActionMapLookup.TryGetValue(actionLookupKey, out _))
         {
-            throw new DuplicateNameException($"The input scheme {schemeName} for the controller {controllerConfiguration.ControllerName} using input definition {inputDefinitionName} already has an input associated to the action key {actionKey} and input phase {inputPhase}.");
+            throw new DuplicateNameException($"The input scheme {schemeName} for the controller {deviceConfiguration.DeviceName} using input definition {inputDefinitionName} already has an input associated to the action key {actionKey} and input phase {inputPhase}.");
         }
 
         _inputActionMapLookup.Add(actionLookupKey, new InputActionMap(actionKey, input.Id, inputPhase));
@@ -77,7 +77,7 @@ internal class InputSchemeBuilder(string inputDefinitionName, IInputDeviceConfig
 
     public InputScheme Build()
     {
-        return new BuiltInInputScheme(inputDefinitionName, controllerConfiguration.ControllerName.Name, schemeName, _isDefault, _inputActionMapLookup.Values);
+        return new BuiltInInputScheme(inputDefinitionName, deviceConfiguration.DeviceName.Name, schemeName, _isDefault, _inputActionMapLookup.Values);
     }
 
     #endregion

--- a/src/OSK.Inputs/Models/Configuration/IInputDeviceConfiguration.cs
+++ b/src/OSK.Inputs/Models/Configuration/IInputDeviceConfiguration.cs
@@ -7,7 +7,7 @@ public interface IInputDeviceConfiguration
 {
     #region Variables
 
-    public InputDeviceName ControllerName { get; }
+    public InputDeviceName DeviceName { get; }
 
     public Type InputReaderType { get; }
 

--- a/src/OSK.Inputs/Models/Configuration/InputDefinition.cs
+++ b/src/OSK.Inputs/Models/Configuration/InputDefinition.cs
@@ -15,7 +15,7 @@ public class InputDefinition(string name, IEnumerable<InputAction> inputActions,
 
     public IEnumerable<InputScheme> InputSchemes => _inputSchemeLookup.Values.SelectMany(schemesByController => schemesByController);
 
-    private readonly Dictionary<string, InputScheme[]> _inputSchemeLookup = inputSchemes.GroupBy(inputScheme => inputScheme.ControllerName.Name)
+    private readonly Dictionary<string, InputScheme[]> _inputSchemeLookup = inputSchemes.GroupBy(inputScheme => inputScheme.DeviceName.Name)
         .ToDictionary(inputControllerSchemeGroup => inputControllerSchemeGroup.Key, 
                       inputControllerSchemeGroup => inputControllerSchemeGroup.OrderBy(scheme => scheme.IsDefault).ThenBy(scheme => scheme.SchemeName).ToArray());
 

--- a/src/OSK.Inputs/Models/Configuration/InputDevice.cs
+++ b/src/OSK.Inputs/Models/Configuration/InputDevice.cs
@@ -14,11 +14,18 @@ public abstract class InputDevice(InputDeviceName deviceName, Type inputReaderTy
 
     internal IInputDeviceConfiguration BuildDeviceConfiguration()
     {
-        var duplicates = AllInputs.GroupBy(input => input.Name).Where(group => group.Count() > 1);
-        if (duplicates.Any())
+                var duplicateIdentifiers = AllInputs.GroupBy(input => input.Id).Where(group => group.Count() > 1);
+        if (duplicateIdentifiers.Any())
         {
-            var error = string.Join(",", duplicates.Select(group => group.Key));
-            throw new DuplicateNameException($"One or more input names had duplicates for the {deviceName} device. The following inputs had the error: {error}");
+            var error = string.Join(",", duplicateIdentifiers.SelectMany(group => group.Select(input => input.Name)));
+            throw new DuplicateNameException($"One or more input names had duplicate ids for the {deviceName} device. The following inputs had the error: {error}");
+        }
+
+        var duplicateNames = AllInputs.GroupBy(input => input.Name).Where(group => group.Count() > 1);
+        if (duplicateNames.Any())
+        {
+            var error = string.Join(",", duplicateNames.Select(group => group.Key));
+            throw new DuplicateNameException($"One or more input names had duplicate names for the {deviceName} device. The following inputs had the error: {error}");
         }
 
         return new DefaultInputDeviceConfiguration(deviceName, inputReaderType, AllInputs, null);

--- a/src/OSK.Inputs/Models/Configuration/InputScheme.cs
+++ b/src/OSK.Inputs/Models/Configuration/InputScheme.cs
@@ -16,7 +16,7 @@ public class InputScheme
     public InputScheme(string inputDefinitionName, InputDeviceName deviceName, string schemeName, bool isDefault, IEnumerable<InputActionMap> inputActions)
     {
         InputDefinitionName = inputDefinitionName;
-        ControllerName = deviceName;
+        DeviceName = deviceName;
         SchemeName = schemeName;
         IsDefault = isDefault;
         InputActionMaps = inputActions.ToArray();
@@ -24,13 +24,19 @@ public class InputScheme
 
     #endregion
 
+    #region Variables
+
+    public const string DefaultSchemeName = "Default";
+
     public string InputDefinitionName { get; }
 
-    public InputDeviceName ControllerName { get; }
+    public InputDeviceName DeviceName { get; }
 
     public string SchemeName { get; }
 
     public bool IsDefault { get; }
 
     public IReadOnlyCollection<InputActionMap> InputActionMaps { get; }
+
+    #endregion
 }

--- a/src/OSK.Inputs/Models/Configuration/InputSystemConfiguration.cs
+++ b/src/OSK.Inputs/Models/Configuration/InputSystemConfiguration.cs
@@ -2,14 +2,14 @@
 using System.Linq;
 
 namespace OSK.Inputs.Models.Configuration;
-public class InputSystemConfiguration(IEnumerable<InputDefinition> inputDefinitions, IEnumerable<IInputDeviceConfiguration> controllerConfigurations, 
+public class InputSystemConfiguration(IEnumerable<InputDefinition> inputDefinitions, IEnumerable<IInputDeviceConfiguration> deviceConfigurations, 
     bool allowCustomInputSchemes, int maxLocalUsers)
 {
     public bool AllowCustomInputSchemes => allowCustomInputSchemes;
 
     public int MaxLocalUsers => maxLocalUsers;
 
-    public IReadOnlyCollection<IInputDeviceConfiguration> SupportedInputControllers { get; } = controllerConfigurations?.ToArray() ?? [];
+    public IReadOnlyCollection<IInputDeviceConfiguration> SupportedInputDevices { get; } = deviceConfigurations?.ToArray() ?? [];
 
     public IReadOnlyCollection<InputDefinition> InputDefinitions { get; } = inputDefinitions?.ToArray() ?? [];
 }

--- a/src/OSK.Inputs/Models/Configuration/Keyboard.cs
+++ b/src/OSK.Inputs/Models/Configuration/Keyboard.cs
@@ -65,7 +65,7 @@ public class Keyboard(Type inputReaderType) : InputDevice(KeyboardName, inputRea
     public static KeyboardCombination LeftParanthesis = new KeyboardCombination(40, "Open Parenthesis", "(", Shift, Nine);
     public static KeyboardCombination RightParanthesis = new KeyboardCombination(41, "Close Parenthesis", ")", Shift, Zero);
     public static KeyboardCombination Underscore = new KeyboardCombination(95, "Underscore", "_", Shift, Minus);
-    public static KeyboardCombination Plus = new KeyboardCombination(42, "Plus", "+", Shift, Equal);
+    public static KeyboardCombination Plus = new KeyboardCombination(43, "Plus", "+", Shift, Equal);
     public static KeyboardCombination LeftCurlyBrace = new KeyboardCombination(123, "Left Curly Brace", "{", Shift, LeftBracket);
     public static KeyboardCombination RightCurlyBrace = new KeyboardCombination(125, "Right Curly Brace", "}", Shift, RightBracket);
     public static KeyboardCombination Colon = new KeyboardCombination(58, "Colon", ":", Shift, SemiColon);
@@ -115,8 +115,9 @@ public class Keyboard(Type inputReaderType) : InputDevice(KeyboardName, inputRea
         Caret, Ampersand, Asterisk, LeftParanthesis, RightParanthesis,
         Underscore, Plus, LeftCurlyBrace, RightCurlyBrace, Colon, DoubleQuote,
         LessThan, GreaterThan, QuestionMark, Pipe,
-        Q, W, E, R, T, Y, U, I, O, P, A, S, D, F, G, H, J, K, L, Z, X, C, V, B,
-        B, N, M,
+        Q, W, E, R, T, Y, U, I, O, P, 
+        A, S, D, F, G, H, J, K, L, 
+        Z, X, C, V, B, N, M,
         UpArrow, LeftArrow, DownArrow, RightArrow
     ];
 

--- a/src/OSK.Inputs/Models/Configuration/PlayStationController.cs
+++ b/src/OSK.Inputs/Models/Configuration/PlayStationController.cs
@@ -5,7 +5,7 @@ using OSK.Inputs.Models.Inputs;
 using OSK.Inputs.Options;
 
 namespace OSK.Inputs.Models.Configuration;
-public class PlayStationControllerDevice(Type inputReaderType) : GamePadDevice(PlayStationControllerName, inputReaderType)
+public class PlayStationController(Type inputReaderType) : GamePadDevice(PlayStationControllerName, inputReaderType)
 {
     #region Static
 

--- a/src/OSK.Inputs/Models/Configuration/SensorController.cs
+++ b/src/OSK.Inputs/Models/Configuration/SensorController.cs
@@ -5,13 +5,13 @@ using OSK.Inputs.Models.Inputs;
 using OSK.Inputs.Options;
 
 namespace OSK.Inputs.Models.Configuration;
-public class SensorControllerDevice(Type inputReaderType): InputDevice(SensorControllerName, inputReaderType)
+public class SensorController(Type inputReaderType): InputDevice(SensorControllerName, inputReaderType)
 {
     #region Static
 
     public static readonly InputDeviceName SensorControllerName = new InputDeviceName("SensorController");
 
-    public static readonly AccelerometerInput Accelerometer = new AccelerometerInput(1);
+    public static readonly AccelerometerInput Accelerometer = new AccelerometerInput(20);
 
     public static readonly TouchInput OneTouch = new TouchInput(1);
     public static readonly TouchInput TwoTouch = new TouchInput(2);

--- a/src/OSK.Inputs/Models/Configuration/XboxController.cs
+++ b/src/OSK.Inputs/Models/Configuration/XboxController.cs
@@ -5,7 +5,7 @@ using OSK.Inputs.Models.Inputs;
 using OSK.Inputs.Options;
 
 namespace OSK.Inputs.Models.Configuration;
-public class XboxControllerDevice(Type inputReaderType) : GamePadDevice(XboxControllerName, inputReaderType)
+public class XboxController(Type inputReaderType) : GamePadDevice(XboxControllerName, inputReaderType)
 {
     #region Static
 

--- a/src/OSK.Inputs/Models/Events/ApplicationUserInputControllerEvent.cs
+++ b/src/OSK.Inputs/Models/Events/ApplicationUserInputControllerEvent.cs
@@ -1,9 +1,0 @@
-﻿using OSK.Inputs.Models.Runtime;
-
-namespace OSK.Inputs.Models.Events;
-public class ApplicationUserInputControllerEvent(IApplicationInputUser user, InputDeviceIdentifier controllerIdentifier)
-{
-    public IApplicationInputUser User => user;
-
-    public InputDeviceIdentifier ControllerIdentifier => controllerIdentifier;
-}

--- a/src/OSK.Inputs/Models/Events/ApplicationUserInputDeviceEvent.cs
+++ b/src/OSK.Inputs/Models/Events/ApplicationUserInputDeviceEvent.cs
@@ -1,0 +1,9 @@
+﻿using OSK.Inputs.Models.Runtime;
+
+namespace OSK.Inputs.Models.Events;
+public class ApplicationUserInputDeviceEvent(IApplicationInputUser user, InputDeviceIdentifier deviceIdentifier)
+{
+    public IApplicationInputUser User => user;
+
+    public InputDeviceIdentifier DeviceIdentifier => deviceIdentifier;
+}

--- a/src/OSK.Inputs/Models/Runtime/ActiveInputScheme.cs
+++ b/src/OSK.Inputs/Models/Runtime/ActiveInputScheme.cs
@@ -3,7 +3,7 @@ public class ActiveInputScheme(int userId, string inputDefinitionName, string de
 {
     public string InputDefinitionName => inputDefinitionName;
 
-    public string ControllerName => deviceName;
+    public string DeviceName => deviceName;
 
     public string ActiveInputSchemeName => schemeName;
 

--- a/src/OSK.Inputs/Models/Runtime/IApplicationInputUser.cs
+++ b/src/OSK.Inputs/Models/Runtime/IApplicationInputUser.cs
@@ -6,7 +6,7 @@ public interface IApplicationInputUser
 {
     int Id { get; }
 
-    IEnumerable<InputDeviceIdentifier> ControllerIdentifiers { get; }
+    IEnumerable<InputDeviceIdentifier> DeviceIdentifiers { get; }
 
     InputDefinition ActiveInputDefinition { get; }
 

--- a/src/OSK.Inputs/Models/Runtime/InputReaderParameters.cs
+++ b/src/OSK.Inputs/Models/Runtime/InputReaderParameters.cs
@@ -3,9 +3,9 @@ using OSK.Inputs.Models.Configuration;
 using OSK.Inputs.Models.Inputs;
 
 namespace OSK.Inputs.Models.Runtime;
-public class InputReaderParameters(InputDeviceIdentifier controllerIdentifier, IEnumerable<IInput> inputs)
+public class InputReaderParameters(InputDeviceIdentifier deviceIdentifier, IEnumerable<IInput> inputs)
 {
-    public InputDeviceIdentifier ControllerIdentifier => controllerIdentifier;
+    public InputDeviceIdentifier DeviceIdentifier => deviceIdentifier;
 
     public IEnumerable<IInput> Inputs => inputs;
 }

--- a/src/OSK.Inputs/Options/InputReadOptions.cs
+++ b/src/OSK.Inputs/Options/InputReadOptions.cs
@@ -3,9 +3,9 @@
 namespace OSK.Inputs.Options;
 public class InputReadOptions
 {
-    public TimeSpan? ControllerReadTime { get; set; }
+    public TimeSpan? DeviceReadTime { get; set; }
 
     public bool RunInputUsersInParallel { get; set; }
 
-    public int MaxConcurrentControllers { get; set; } = 1;
+    public int MaxConcurrentDevices { get; set; } = 1;
 }

--- a/src/OSK.Inputs/Options/JoinUserOptions.cs
+++ b/src/OSK.Inputs/Options/JoinUserOptions.cs
@@ -10,7 +10,7 @@ public class JoinUserOptions
 
     #endregion
 
-    public IEnumerable<InputDeviceIdentifier> ControllerIdentifiers { get; set; } = [];
+    public IEnumerable<InputDeviceIdentifier> DeviceIdentifiers { get; set; } = [];
 
     public string? ActiveInputDefinitionName { get; set; } = null;
 }

--- a/src/OSK.Inputs/Ports/IInputManager.cs
+++ b/src/OSK.Inputs/Ports/IInputManager.cs
@@ -16,13 +16,13 @@ public interface IInputManager
 {
     InputSystemConfiguration Configuration { get; }
 
-    event Action<ApplicationUserInputControllerEvent> OnInputControllerDisconnected;
-    event Action<ApplicationUserInputControllerEvent> OnInputControllerConnected;
-    event Action<ApplicationUserInputControllerEvent> OnInputControllerAdded;
+    event Action<ApplicationUserInputDeviceEvent> OnInputDeviceDisconnected;
+    event Action<ApplicationUserInputDeviceEvent> OnInputDeviceConnected;
+    event Action<ApplicationUserInputDeviceEvent> OnInputDeviceAdded;
 
     Task<IOutput<IApplicationInputUser>> JoinUserAsync(int userId, JoinUserOptions options, CancellationToken cancellationToken = default);
     void RemoveUser(int userId);
-    void PairController(int userId, InputDeviceIdentifier controllerIdentifier);
+    void PairController(int userId, InputDeviceIdentifier deviceIdentifier);
     IEnumerable<IApplicationInputUser> GetApplicationInputUsers();
     IApplicationInputUser GetApplicationInputUser(int userId);
 

--- a/src/OSK.Inputs/Ports/IInputReaderProvider.cs
+++ b/src/OSK.Inputs/Ports/IInputReaderProvider.cs
@@ -7,5 +7,5 @@ namespace OSK.Inputs.Ports;
 [HexagonalIntegration(HexagonalIntegrationType.LibraryProvided, HexagonalIntegrationType.IntegrationOptional)]
 public interface IInputReaderProvider
 {
-    IInputReader GetInputReader(IInputDeviceConfiguration controllerConfiguration, InputDeviceIdentifier controllerIdentifier);
+    IInputReader GetInputReader(IInputDeviceConfiguration deviceConfiguration, InputDeviceIdentifier deviceIdentifier);
 }


### PR DESCRIPTION
Motivation
----
The current project has a couple of device configuration bugs preventing usage with DI and there are remnants of old naming conventions

Modifications
----
* Refactored almost all references to the old 'Controller' naming convention and replaced with 'Device' naming
* Fixed device input configurations that were broken
* Added unit tests for device configuration validation

Result
----
Naming conventions align with project goals and issues with input configurations are fixed

Fixes #7