### PR TITLE
Add Missing IGamePadInput port to GamePadStickInput (OSK-17)

### DIFF
--- a/src/OSK.Inputs/Models/Inputs/GamePadStickInput.cs
+++ b/src/OSK.Inputs/Models/Inputs/GamePadStickInput.cs
@@ -1,6 +1,6 @@
 ﻿using OSK.Inputs.Models.Configuration;
 
 namespace OSK.Inputs.Models.Inputs;
-public class GamePadStickInput(int id, string name): AnalogInput(id, name, GamePadDevice.DeviceTypeName)
+public class GamePadStickInput(int id, string name): AnalogInput(id, name, GamePadDevice.DeviceTypeName), IGamePadInput
 {
 }


### PR DESCRIPTION
Motivation
----
The current game pad stick input is missing a needed interface for it to be usable as an IGamePadInput

Modifications
----
* Add missing interface

Result
----
The GamePadStickInput is able to behave as expected

Fixes #17