### PR TITLE
Add UserId to InputActivationEvent (OSK-19)

### DIFF
--- a/src/OSK.Inputs/Models/Events/InputActivationEvent.cs
+++ b/src/OSK.Inputs/Models/Events/InputActivationEvent.cs
@@ -3,9 +3,11 @@ using OSK.Inputs.Models.Configuration;
 using OSK.Inputs.Models.Runtime;
 
 namespace OSK.Inputs.Models.Events;
-public class InputActivationEvent(IServiceProvider serviceProvider, ActivatedInput input, InputAction inputAction)
+public class InputActivationEvent(IServiceProvider serviceProvider, int userId, ActivatedInput input, InputAction inputAction)
 {
     public IServiceProvider Services => serviceProvider;
+
+    public int UserId => userId;
 
     public ActivatedInput Input => input;
 

--- a/src/OSK.Inputs/Models/Runtime/InputActivationContext.cs
+++ b/src/OSK.Inputs/Models/Runtime/InputActivationContext.cs
@@ -18,7 +18,7 @@ public class InputActivationContext(IServiceProvider serviceProvider, IEnumerabl
             InputActivationDelegate executionDelegate =
                 @event => command.InputAction.ActionExecutor(@event);
 
-            var activationEvent = new InputActivationEvent(serviceProvider, command.ActivatedInput, command.InputAction);
+            var activationEvent = new InputActivationEvent(serviceProvider, command.UserId, command.ActivatedInput, command.InputAction);
             if (middleware != null)
             {
                 await middleware(executionDelegate, activationEvent);


### PR DESCRIPTION
Motivation
----
The current InputActivationEvent is lacking context for the user the input being activated and discerning this can be difficult if not impossible

Modifications
----
* Add UserId to InputActivationEvent
* Set the event user id when the activation context runs the commands generated from input

Result
----
UserId is now available to integrations with the input library

Fixes #19