### PR TITLE
Fix input controller user assignment (OSK-21)

### DIFF
--- a/src/OSK.Inputs/Internal/ApplicationInputUser.cs
+++ b/src/OSK.Inputs/Internal/ApplicationInputUser.cs
@@ -75,7 +75,7 @@ internal class ApplicationInputUser(int userId, InputSystemConfiguration inputSy
 
         if (ActiveInputDefinition is not null)
         {
-            SetActiveInputDefinition(ActiveInputDefinition, _inputControllers.Values.Select(controller => controller.InputScheme));
+            SetActiveInputDefinition(ActiveInputDefinition, _inputControllers.Values.Select(controller => controller.InputScheme).ToArray());
         }
     }
 
@@ -88,7 +88,7 @@ internal class ApplicationInputUser(int userId, InputSystemConfiguration inputSy
         foreach (var scheme in activeInputSchemes)
         {
             var controllerConfiguration = inputSystemConfiguration.InputControllers.FirstOrDefaultByString(
-                controller => scheme.ControllerId, scheme.ControllerId);
+                controller => controller.ControllerName, scheme.ControllerId);
             if (controllerConfiguration is null)
             {
                 continue;


### PR DESCRIPTION
Motivation
----
Pairing a device one at a time seems to cause issues with input controller assignment, with no input controller being assigned even when the input devices needed for it are given to a user. No input is then recorded by the controller since it was never created

Modifications
----
* Update ApplicationInputUser to ensure that input controllers are created as new input devices are added

Result
----
Input controllers are assigned as expected even when pairing devices individually