### PR TITLE
Allow changing MaxLocalUSers at runtime and unpair device method (OSK-23)

### DIFF
--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputManagerTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputManagerTests.cs
@@ -1135,4 +1135,84 @@ public class InputManagerTests
 
 
     #endregion
+
+    #region UpdateMaxLocalUsers
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void UpdateMaxLocalUsers_SetToInvalidValue_Fails(int invalidValue)
+    {
+        // Arrange
+        var originalMax = _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers;
+
+        // Act
+        var result = _2UserManagerWithNoCustomSchemes.UpdateMaxLocalUsers(invalidValue);
+
+        // Assert
+        Assert.False(result.IsSuccessful);
+        // Reset to original value
+        _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers = originalMax;
+    }
+
+    [Fact]
+    public async Task UpdateMaxLocalUsers_DecreaseBelowCurrentUserCount_Fails()
+    {
+        // Arrange
+        var originalMax = _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers;
+
+        // Join two users
+        _mockInputSchemeRepository.Setup(m => m.GetActiveInputSchemesAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_outputFactory.Succeed(Enumerable.Empty<ActiveInputScheme>()));
+        _mockInputReaderProvider.Setup(m => m.GetInputReader(It.IsAny<IInputDeviceConfiguration>(), It.IsAny<InputDeviceIdentifier>()))
+            .Returns(Mock.Of<IInputDeviceReader>());
+
+        await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
+        await _2UserManagerWithNoCustomSchemes.JoinUserAsync(2, JoinUserOptions.Default);
+
+        // Try to set max local users to 1 (less than current user count)
+        var result = _2UserManagerWithNoCustomSchemes.UpdateMaxLocalUsers(1);
+
+        // Assert
+        Assert.False(result.IsSuccessful);
+        // Reset to original value
+        _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers = originalMax;
+    }
+
+    [Fact]
+    public void UpdateMaxLocalUsers_SetToSameValue_Succeeds()
+    {
+        // Arrange
+        var originalMax = _4UserManagerWithCustomSchemes.Configuration.MaxLocalUsers;
+
+        // Act
+        var result = _4UserManagerWithCustomSchemes.UpdateMaxLocalUsers(originalMax);
+
+        // Assert
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(originalMax, _4UserManagerWithCustomSchemes.Configuration.MaxLocalUsers);
+
+        // Reset to original value
+        _4UserManagerWithCustomSchemes.Configuration.MaxLocalUsers = originalMax;
+    }
+
+    [Fact]
+    public void UpdateMaxLocalUsers_IncreaseMaxLocalUsers_Succeeds()
+    {
+        // Arrange
+        var originalMax = _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers;
+        var newMax = originalMax + 2;
+
+        // Act
+        var result = _2UserManagerWithNoCustomSchemes.UpdateMaxLocalUsers(newMax);
+
+        // Assert
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(newMax, _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers);
+
+        // Reset to original value
+        _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers = originalMax;
+    }
+
+    #endregion
 }

--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputManagerTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputManagerTests.cs
@@ -1136,27 +1136,33 @@ public class InputManagerTests
 
     #endregion
 
-    #region UpdateMaxLocalUsers
+    #region Reconfigure
+
+    [Fact]
+    public void Reconfigure_NullConfiguration_ThrowsArgumentNullException()
+    {
+        // Arrange/Act/Assert
+        Assert.Throws<ArgumentNullException>(() => _2UserManagerWithNoCustomSchemes.Reconfigure(null!));
+    }
 
     [Theory]
     [InlineData(0)]
     [InlineData(-1)]
-    public void UpdateMaxLocalUsers_SetToInvalidValue_Fails(int invalidValue)
+    public void Reconfigure_SetInvalidMaxLocalUsers_Fails(int invalidValue)
     {
         // Arrange
         var originalMax = _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers;
 
         // Act
-        var result = _2UserManagerWithNoCustomSchemes.UpdateMaxLocalUsers(invalidValue);
+        var result = _2UserManagerWithNoCustomSchemes.Reconfigure(configurator => configurator.SetMaxLocalUsers(invalidValue));
 
         // Assert
         Assert.False(result.IsSuccessful);
-        // Reset to original value
-        _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers = originalMax;
+        Assert.Equal(originalMax, _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers);
     }
 
     [Fact]
-    public async Task UpdateMaxLocalUsers_DecreaseBelowCurrentUserCount_Fails()
+    public async Task Reconfigure_DecreaseMaxLocalUsersBelowCurrentUserCount_Fails()
     {
         // Arrange
         var originalMax = _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers;
@@ -1170,48 +1176,55 @@ public class InputManagerTests
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(1, JoinUserOptions.Default);
         await _2UserManagerWithNoCustomSchemes.JoinUserAsync(2, JoinUserOptions.Default);
 
-        // Try to set max local users to 1 (less than current user count)
-        var result = _2UserManagerWithNoCustomSchemes.UpdateMaxLocalUsers(1);
+        // Act
+        var result = _2UserManagerWithNoCustomSchemes.Reconfigure(configurator => configurator.SetMaxLocalUsers(1));
 
         // Assert
         Assert.False(result.IsSuccessful);
-        // Reset to original value
-        _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers = originalMax;
+        Assert.Equal(originalMax, _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers);
     }
 
     [Fact]
-    public void UpdateMaxLocalUsers_SetToSameValue_Succeeds()
+    public void Reconfigure_SetSameMaxLocalUsers_Succeeds()
     {
         // Arrange
         var originalMax = _4UserManagerWithCustomSchemes.Configuration.MaxLocalUsers;
 
         // Act
-        var result = _4UserManagerWithCustomSchemes.UpdateMaxLocalUsers(originalMax);
+        var result = _4UserManagerWithCustomSchemes.Reconfigure(configurator => configurator.SetMaxLocalUsers(originalMax));
 
         // Assert
         Assert.True(result.IsSuccessful);
         Assert.Equal(originalMax, _4UserManagerWithCustomSchemes.Configuration.MaxLocalUsers);
-
-        // Reset to original value
-        _4UserManagerWithCustomSchemes.Configuration.MaxLocalUsers = originalMax;
     }
 
     [Fact]
-    public void UpdateMaxLocalUsers_IncreaseMaxLocalUsers_Succeeds()
+    public void Reconfigure_IncreaseMaxLocalUsers_Succeeds()
     {
         // Arrange
         var originalMax = _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers;
         var newMax = originalMax + 2;
 
         // Act
-        var result = _2UserManagerWithNoCustomSchemes.UpdateMaxLocalUsers(newMax);
+        var result = _2UserManagerWithNoCustomSchemes.Reconfigure(configurator => configurator.SetMaxLocalUsers(newMax));
 
         // Assert
         Assert.True(result.IsSuccessful);
         Assert.Equal(newMax, _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers);
+    }
 
-        // Reset to original value
-        _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers = originalMax;
+    [Fact]
+    public void Reconfigure_NoMaxLocalUsersSet_DoesNotChangeValueAndSucceeds()
+    {
+        // Arrange
+        var originalMax = _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers;
+
+        // Act
+        var result = _2UserManagerWithNoCustomSchemes.Reconfigure(_ => { });
+
+        // Assert
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(originalMax, _2UserManagerWithNoCustomSchemes.Configuration.MaxLocalUsers);
     }
 
     #endregion

--- a/src/OSK.Inputs/Internal/ApplicationInputUser.cs
+++ b/src/OSK.Inputs/Internal/ApplicationInputUser.cs
@@ -79,6 +79,17 @@ internal class ApplicationInputUser(int userId, InputSystemConfiguration inputSy
         }
     }
 
+    public void RemoveInputDevice(InputDeviceIdentifier deviceIdentifier)
+    {
+        if (_userInputDeviceLookup.TryGetValue(deviceIdentifier.DeviceId, out var inputDevice)) 
+        {
+            _userInputDeviceLookup.Remove(deviceIdentifier.DeviceId);
+            inputDevice.Dispose();
+
+            SetActiveInputDefinition(ActiveInputDefinition, _inputControllers.Values.Select(controller => controller.InputScheme).ToArray());
+        }
+    }
+
     public void SetActiveInputDefinition(InputDefinition inputDefinition, IEnumerable<InputScheme> activeInputSchemes)
     {
         ActiveInputDefinition = inputDefinition;

--- a/src/OSK.Inputs/Internal/Services/InputManager.cs
+++ b/src/OSK.Inputs/Internal/Services/InputManager.cs
@@ -294,6 +294,21 @@ internal class InputManager(InputSystemConfiguration inputSystemConfiguration, I
         return _userLookup.Values;
     }
 
+    public IOutput UpdateMaxLocalUsers(int maxLocalUsers)
+    {
+        if (maxLocalUsers <= 0)
+        {
+            return outputFactory.Fail($"The maximum number of local users must be greater than or equal to 0, but was {maxLocalUsers}.");
+        }
+        if (maxLocalUsers < _userLookup.Count)
+        {
+            return outputFactory.Fail($"The maximum number of local users must be greater than or equal to the current number of users ({_userLookup.Count}), but was {maxLocalUsers}.");
+        }
+
+        Configuration.MaxLocalUsers = maxLocalUsers;
+        return outputFactory.Succeed();
+    }
+
     public async Task<InputActivationContext> ReadInputsAsync(InputReadOptions readOptions, CancellationToken cancellationToken = default)
     {
         CancellationToken[] cancellationTokens = readOptions.DeviceReadTime.HasValue && readOptions.DeviceReadTime > TimeSpan.Zero

--- a/src/OSK.Inputs/Models/Configuration/InputSystemConfiguration.cs
+++ b/src/OSK.Inputs/Models/Configuration/InputSystemConfiguration.cs
@@ -7,7 +7,7 @@ public class InputSystemConfiguration(IEnumerable<InputDefinition> inputDefiniti
 {
     public bool AllowCustomInputSchemes => allowCustomInputSchemes;
 
-    public int MaxLocalUsers => maxLocalUsers;
+    public int MaxLocalUsers { get; internal set; } = maxLocalUsers;
 
     public IReadOnlyCollection<InputControllerConfiguration> InputControllers { get; } = controllerConfigurations.ToArray();
 

--- a/src/OSK.Inputs/Models/Runtime/InputDeviceIdentifier.cs
+++ b/src/OSK.Inputs/Models/Runtime/InputDeviceIdentifier.cs
@@ -2,10 +2,22 @@
 using OSK.Inputs.Models.Configuration;
 
 namespace OSK.Inputs.Models.Runtime;
+
+/// <summary>
+/// A struct that represents a specific input device
+/// </summary>
+/// <param name="deviceId">The device's input system id</param>
+/// <param name="deviceName">The name of the input device</param>
 public struct InputDeviceIdentifier(int deviceId, InputDeviceName deviceName)
 {
+    /// <summary>
+    /// The input system's unique id for the device
+    /// </summary>
     public int DeviceId => deviceId;
 
+    /// <summary>
+    /// The name of the input device
+    /// </summary>
     public InputDeviceName DeviceName => deviceName;
 
     #region Operators

--- a/src/OSK.Inputs/Models/Runtime/InputManagerRuntimeConfigurator.cs
+++ b/src/OSK.Inputs/Models/Runtime/InputManagerRuntimeConfigurator.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using OSK.Inputs.Models.Configuration;
+
+namespace OSK.Inputs.Models.Runtime;
+
+/// <summary>
+/// A data object that allows configuring certain <see cref="InputSystemConfiguration"/> settings at runtime
+/// </summary>
+public class InputManagerRuntimeConfigurator
+{
+    #region Variables
+
+    internal int? MaxLocalUsers { get; private set; }
+
+    #endregion
+
+    public InputManagerRuntimeConfigurator SetMaxLocalUsers(int maxLocalUsers)
+    {
+        MaxLocalUsers = maxLocalUsers;
+        return this;
+    }
+}

--- a/src/OSK.Inputs/Models/Runtime/InputPower.cs
+++ b/src/OSK.Inputs/Models/Runtime/InputPower.cs
@@ -5,17 +5,37 @@ using System.Linq;
 namespace OSK.Inputs.Models.Runtime;
 
 /// <summary>
-/// Represents the power that a particlar <see cref="ActivatedInput"/> has
+/// Represents the power that a particlar <see cref="ActivatedInput"/> has in anaglog inputs. Power ranges from -1 to 1, where 0 is no power and 1 is full power.
 /// </summary>
 /// <param name="inputPower">The enumerable representing the input power on different axes of a particular input (a joystick has x/y axes for example)</param>
 public class InputPower(IEnumerable<float> inputPower)
 {
     #region Static
 
+    /// <summary>
+    /// An empty input power, representing no power on any axis
+    /// </summary>
     public static InputPower None => new InputPower([]);
 
+    /// <summary>
+    /// Creates an input power with full power on all axes, in the forward direction, where the axis count is specified
+    /// </summary>
+    /// <param name="axisCount">The total number of axes that should be set to full power</param>
+    /// <returns>An input power with all axes set to full</returns>
     public static InputPower FullPower(int axisCount) => new InputPower(Enumerable.Repeat(1f, axisCount));
 
+    /// <summary>
+    /// Creates an input power with full power on all axes, in the reverse direction, where the axis count is specified
+    /// </summary>
+    /// <param name="axisCount">The total number of axes that should be set to full rever power</param>
+    /// <returns>An input power with all axes set to full reverse</returns>
+    public static InputPower ReverseFullPower(int axisCount) => new InputPower(Enumerable.Repeat(-1f, axisCount));
+
+    /// <summary>
+    /// Creates an input power from a set of power levels, where each level corresponds to an axis of the input
+    /// </summary>
+    /// <param name="powerLevels">The set of power levels for each corresponding axis</param>
+    /// <returns>An input power representing all of the axes power levels</returns>
     public static InputPower FromPowerLevels(params float[] powerLevels) => new InputPower(powerLevels);
 
     #endregion
@@ -28,6 +48,23 @@ public class InputPower(IEnumerable<float> inputPower)
 
     #region Helpers
 
+    /// <summary>
+    /// An indexer to access the input power for a specific axis by its index. Short-hand for <see cref="GetAxis(int)"/>
+    /// </summary>
+    /// <param name="index">The specific index to grab input power for</param>
+    /// <returns>The power for the axis</returns>
+    float this[int index] => GetAxis(index);
+
+    /// <summary>
+    /// Retrieves the input power for a specific axis, clamped to -1 to 1.
+    /// 
+    /// <br />
+    /// <br />
+    /// Note: If the index is greater than the number of axes, it will return 0.
+    /// </summary>
+    /// <param name="axisIndex">The axis index to get input power for</param>
+    /// <returns>The power of the axis, clamped between -1 to 1</returns>
+    /// <exception cref="IndexOutOfRangeException">If the axis index is below 0</exception>
     public float GetAxis(int axisIndex)
     {
         if (axisIndex < 0)

--- a/src/OSK.Inputs/Models/Runtime/InputReaderParameters.cs
+++ b/src/OSK.Inputs/Models/Runtime/InputReaderParameters.cs
@@ -1,10 +1,23 @@
 ﻿using System.Collections.Generic;
 using OSK.Inputs.Models.Inputs;
+using OSK.Inputs.Ports;
 
 namespace OSK.Inputs.Models.Runtime;
+
+/// <summary>
+/// Initialization parameters for input readers that are created by the <see cref="IInputReaderProvider"/>
+/// </summary>
+/// <param name="deviceIdentifier">The identifier for the device</param>
+/// <param name="inputs">The specific inputs that a reader should initialize and support for the current input system</param>
 public class InputReaderParameters(InputDeviceIdentifier deviceIdentifier, IEnumerable<IInput> inputs)
 {
+    /// <summary>
+    /// The identifier for the device that the input reader will be associated with
+    /// </summary>
     public InputDeviceIdentifier DeviceIdentifier => deviceIdentifier;
 
+    /// <summary>
+    /// The specific inputs that the input reader should initialize and support
+    /// </summary>
     public IEnumerable<IInput> Inputs => inputs;
 }

--- a/src/OSK.Inputs/Models/Runtime/PointerInformation.cs
+++ b/src/OSK.Inputs/Models/Runtime/PointerInformation.cs
@@ -1,25 +1,53 @@
 ﻿using System.Numerics;
 
 namespace OSK.Inputs.Models.Runtime;
+
+/// <summary>
+/// The pointer information for use with an input. This is the location of the input pointer on the screen at the time the input was triggered
+/// </summary>
+/// <param name="pointerId">The specific pointer id. This could vary depending on how many touches or mice are used</param>
+/// <param name="pointerPositions">The set of pointer data for the current pointer id over the course of an input. This data set represents the history of travel, i.e. for swipe related data processing if needed</param>
 public class PointerInformation(int pointerId, Vector2[] pointerPositions)
 {
+    /// <summary>
+    /// A default pointer id, if specific pointer id data is not required
+    /// </summary>
     public const int DefaultPointerId = 999;
 
+    /// <summary>
+    /// Default pointer information for an empty data set of pointer information
+    /// </summary>
     public static PointerInformation Default { get; } = new PointerInformation(DefaultPointerId, []);
 
+    /// <summary>
+    /// The pointer id for the input. This is used to differentiate between multiple pointers, such as in touch or multi-mouse scenarios
+    /// </summary>
     public int PointerId => pointerId;
 
+    /// <summary>
+    /// The current position of the pointer, especailly useful if a data set exists for pointer position hisstory
+    /// </summary>
     public Vector2 CurrentPosition => pointerPositions.Length == 1
         ? pointerPositions[^1]
         : Vector2.Zero;
 
+    /// <summary>
+    /// The previous pointer position, if available, and is useful for calculating deltas or changes in position. 
+    /// This will be the the value of the current position if no previous position exists.
+    /// </summary>
     public Vector2 PreviousPosition => pointerPositions.Length > 1
         ? pointerPositions[^2]
         : CurrentPosition;
 
+    /// <summary>
+    /// The delta between the current and previous pointer positions. This is useful for determining movement or changes in position.
+    /// </summary>
     public Vector2 Delta { get; } = pointerPositions.Length <= 1 
         ? Vector2.Zero 
         : pointerPositions[^1] - pointerPositions[^2];
 
+    /// <summary>
+    /// The list of pointer positions for the current pointer id. This is useful for tracking the history of pointer movements, such as for swipe gestures or other input patterns.
+    /// </summary>
     public Vector2[] PointerPositions => pointerPositions;
 }

--- a/src/OSK.Inputs/Models/Runtime/UserActionCommand.cs
+++ b/src/OSK.Inputs/Models/Runtime/UserActionCommand.cs
@@ -1,11 +1,27 @@
 ﻿using OSK.Inputs.Models.Configuration;
 
 namespace OSK.Inputs.Models.Runtime;
+
+/// <summary>
+/// Represents a finalized user action command after input information has been received and processed
+/// </summary>
+/// <param name="userId">The user id the command was executed by</param>
+/// <param name="activatedInput">The input that was activated</param>
+/// <param name="inputAction">The input action that was triggered</param>
 public class UserActionCommand(int userId, ActivatedInput activatedInput, InputAction inputAction)
 {
+    /// <summary>
+    /// The user id that the command was generated for
+    /// </summary>
     public int UserId => userId;
 
+    /// <summary>
+    /// The input that triggered the command
+    /// </summary>
     public ActivatedInput ActivatedInput => activatedInput;
 
+    /// <summary>
+    /// The related input action that is associated with the input
+    /// </summary>
     public InputAction InputAction => inputAction;
 }

--- a/src/OSK.Inputs/Ports/IInputManager.cs
+++ b/src/OSK.Inputs/Ports/IInputManager.cs
@@ -106,5 +106,12 @@ public interface IInputManager
     Task<IOutput> DeleteCustomInputSchemeAsync(string inputDefinitionName, string controllerId, string schemeName,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Attempts to set the maximum number of users that the input system will allow locally
+    /// </summary>
+    /// <param name="maxLocalUsers">The total number of ussers the input system will allow locally</param>
+    /// <returns>An output that represents the outcome of the function</returns>
+    IOutput UpdateMaxLocalUsers(int maxLocalUsers);
+
     Task<InputActivationContext> ReadInputsAsync(InputReadOptions readOptions, CancellationToken cancellationToken = default);
 }

--- a/src/OSK.Inputs/Ports/IInputManager.cs
+++ b/src/OSK.Inputs/Ports/IInputManager.cs
@@ -58,6 +58,12 @@ public interface IInputManager
     void PairDevice(int userId, InputDeviceIdentifier deviceIdentifier);
 
     /// <summary>
+    /// Unpairs a device from the input system and associated user
+    /// </summary>
+    /// <param name="deviceIdentifier">The device identifier that will be unpaired</param>
+    void UnpairDevice(InputDeviceIdentifier deviceIdentifier);
+
+    /// <summary>
     /// Gets all the users that have been joined to the input manager
     /// </summary>
     /// <returns>A collection of the input users attached to the input manager</returns>
@@ -107,11 +113,11 @@ public interface IInputManager
         CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Attempts to set the maximum number of users that the input system will allow locally
+    /// Attempts to reconfigure the input manager with a new configuration
     /// </summary>
-    /// <param name="maxLocalUsers">The total number of ussers the input system will allow locally</param>
-    /// <returns>An output that represents the outcome of the function</returns>
-    IOutput UpdateMaxLocalUsers(int maxLocalUsers);
+    /// <param name="configuration">The configuration action to apply to a new input configuration that the input manager will use/</param>
+    /// <returns>An output that represents the outcome of the configuration attempt</returns>
+    IOutput Reconfigure(Action<InputManagerRuntimeConfigurator> configuration);
 
     Task<InputActivationContext> ReadInputsAsync(InputReadOptions readOptions, CancellationToken cancellationToken = default);
 }

--- a/src/OSK.Inputs/ServiceCollectionExtensions.cs
+++ b/src/OSK.Inputs/ServiceCollectionExtensions.cs
@@ -16,9 +16,12 @@ public static class ServiceCollectionExtensions
         }
 
         services.TryAddTransient<IInputDefinitionBuilder, InputDefinitionBuilder>();
-        services.TryAddTransient<IInputManager, InputManager>();
         services.TryAddTransient<IInputReaderProvider, DefaultInputReaderProvider>();
         services.TryAddTransient<IInputValidationService, InputValidationService>();
+
+        // Making a singleton so that we don't lose the user information and data whenever
+        // an input system object is request from the DI container
+        services.TryAddSingleton<IInputManager, InputManager>();
 
         var builder = new InputSystemBuilder(services);
         builderConfiguration(builder);


### PR DESCRIPTION
Motivation
----
Applications utilizing the library don't have the ability to fully set the max local users at runtime

Modifications
----
* Allow internal edits to the max local user variable of a configuration
* Add new endpiont for adjusting the max local users in the InputManager
* Update ServiceCollectionExtensions to make InputManager a singleton
* Add new UnitTests

Result
----
The ability to update the max local users is available to Applications

Fixes #23