### PR TITLE
Support Registering Service Methods Directly (OSK-28)

### DIFF
--- a/src/OSK.Inputs.UnitTests/Internal/Services/InputDefinitionBuilderTests.cs
+++ b/src/OSK.Inputs.UnitTests/Internal/Services/InputDefinitionBuilderTests.cs
@@ -3,6 +3,7 @@ using Moq;
 using OSK.Inputs.Internal.Services;
 using OSK.Inputs.Models.Configuration;
 using OSK.Inputs.Models.Inputs;
+using OSK.Inputs.UnitTests._Helpers;
 using Xunit;
 
 namespace OSK.Inputs.UnitTests.Internal.Services;
@@ -154,6 +155,24 @@ public class InputDefinitionBuilderTests
         Assert.Contains(action2, definition.InputActions);
 
         Assert.Equal(3, definition.InputSchemes.Count());
+    }
+
+    [Fact]
+    public void Build_TestRegistrationService_Valid_ReturnsInputDefinition()
+    {
+        // Arrange
+        _builder.RegisterActions<TestRegistrationService>();
+
+        // Act
+        var definition = _builder.Build();
+
+        // Assert
+        Assert.NotNull(definition);
+
+        Assert.Equal(2, definition.InputActions.Count);
+
+        Assert.True(definition.InputActions.Count(action => nameof(TestRegistrationService.ValidMethodA).Equals(action.ActionKey)) == 1);
+        Assert.True(definition.InputActions.Count(action => "SpecialAction".Equals(action.ActionKey)) == 1);
     }
 
     #endregion

--- a/src/OSK.Inputs.UnitTests/_Helpers/TestRegistrationService.cs
+++ b/src/OSK.Inputs.UnitTests/_Helpers/TestRegistrationService.cs
@@ -1,0 +1,37 @@
+﻿using OSK.Inputs.Attributes;
+using OSK.Inputs.Models.Events;
+
+namespace OSK.Inputs.UnitTests._Helpers;
+
+public class TestRegistrationService
+{
+    public ValueTask ValidMethodA(InputActivationEvent activationEvent)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    [InputAction("SpecialAction")]
+    public ValueTask ValidMethodB(InputActivationEvent activationEvent)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public void InvalidMethodA(InputActivationEvent activationEvent) 
+    { 
+    }
+
+    public int InvalidMethodB(InputActivationEvent activationEvent)
+    {
+        return 1;
+    }
+
+    public ValueTask InvalidMethodC()
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask InvalidMethodD(InputActivationEvent activationEvent, int a)
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/OSK.Inputs/Attributes/InputActionAttribute.cs
+++ b/src/OSK.Inputs/Attributes/InputActionAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace OSK.Inputs.Attributes;
+
+[AttributeUsage(AttributeTargets.Method)]
+public class InputActionAttribute : Attribute
+{
+    #region Variables
+
+    public string? ActionName { get; }
+
+    public string? Description { get; }
+
+    #endregion
+
+    #region Constructors
+
+    public InputActionAttribute(string actionName, string? description = null)
+    {
+        ActionName = actionName?.Trim();
+        Description = description;
+    }
+
+    #endregion
+}

--- a/src/OSK.Inputs/InputDefinitionBuilderExtensions.cs
+++ b/src/OSK.Inputs/InputDefinitionBuilderExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using System;
+using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using OSK.Expressions.Invoker;
+using OSK.Inputs.Attributes;
 using OSK.Inputs.Models.Configuration;
 using OSK.Inputs.Models.Events;
 using OSK.Inputs.Ports;
@@ -9,6 +13,35 @@ namespace OSK.Inputs;
 
 public static class InputDefinitionBuilderExtensions
 {
+    #region Registrations
+
+    public static IInputDefinitionBuilder RegisterActions<T>(this IInputDefinitionBuilder builder)
+        where T : notnull
+    {
+        var methodsToRegister = typeof(T).GetMethods().Where(method =>
+        {
+            var methodParameters = method.GetParameters();
+            return methodParameters.Length is 1 && methodParameters[0].ParameterType == typeof(InputActivationEvent)
+             && method.ReturnParameter.ParameterType == typeof(ValueTask);
+        });
+
+        foreach (var method in methodsToRegister)
+        {
+            var inputActionAttribute = method.GetCustomAttribute<InputActionAttribute>();
+            var inputActionName = string.IsNullOrWhiteSpace(inputActionAttribute?.ActionName) 
+                ? method.Name 
+                : inputActionAttribute.ActionName;
+            var invoker = InvokerFactory.CreateInvoker<T>(method);
+
+            builder.AddAction<T>(inputActionName, inputActionAttribute?.Description, 
+                (service, activationEvent) => invoker.FastInvoke<ValueTask>(service, [activationEvent]));
+        }
+
+        return builder;
+    }
+
+    #endregion
+
     #region Actions
 
     public static IInputDefinitionBuilder AddAction<TService>(this IInputDefinitionBuilder builder, string actionName,

--- a/src/OSK.Inputs/OSK.Inputs.csproj
+++ b/src/OSK.Inputs/OSK.Inputs.csproj
@@ -19,8 +19,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
+		<PackageReference Include="OSK.Expressions.Invoker" Version="1.1.0" />
 		<PackageReference Include="OSK.Functions.Outputs.Logging.Abstractions" Version="2.2.0" />
 		<PackageReference Include="OSK.Hexagonal.Abstractions" Version="0.5.0" />
 		<PackageReference Include="OSK.Hexagonal.MetaData" Version="1.0.0" />


### PR DESCRIPTION
Motivation
----
The current way of adding action methods to the input system is cumbersome and doesn't lend well to large amounts of input methods

Modifications
----
* Added new mechanism to register an entire class worth of methods as input actions
  * New format of method expects a return type of `ValueTask` with a single parameter for `InputActionEvent`
* Added new InputActionAttribute to allow customizing action names and definitions for an input method
* Added UnitTests for the new mechanism

Result
----
Library allows adding an entire input action list from a service Directly

Fixes #28