### PR TITLE
Remove explicit typing mandate on InputDeviceMapBuilder (OSK-47)

### DIFF
--- a/src/OSK.Extensions.Inputs.Configuration/InputDeviceMapBuilderExtensions.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/InputDeviceMapBuilderExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq.Expressions;
 using OSK.Extensions.Inputs.Configuration.Ports;
 using OSK.Inputs.Abstractions.Devices;
 
@@ -7,47 +6,11 @@ namespace OSK.Extensions.Inputs.Configuration;
 
 public static class InputDeviceMapBuilderExtensions
 {
-    public static IInputDeviceMapBuilder<TDeviceSpecification, TInput> WithInput<TDeviceSpecification, TInput, TService>(
-        this IInputDeviceMapBuilder<TDeviceSpecification, TInput> builder, TInput input, Expression<Func<TService, object?>> methodPath)
+    public static IInputDeviceMapBuilder WithInput<TDeviceSpecification, TInput>(
+        this IInputDeviceMapBuilder builder, TInput input, string actionKey)
         where TInput : Enum
-        where TDeviceSpecification : InputDeviceSpecification<TInput>, new()
+        where TDeviceSpecification : InputDeviceSpecification<TInput>
     {
-        return builder.WithInputMap(input, GetMethodName(methodPath));
+        return builder.WithInputMap(Convert.ToInt32(input), actionKey);
     }
-
-    public static IInputDeviceMapBuilder<TDeviceSpecification, TInput> WithInput<TDeviceSpecification, TInput>(
-        this IInputDeviceMapBuilder<TDeviceSpecification, TInput> builder, TInput input, string actionKey)
-        where TInput : Enum
-        where TDeviceSpecification : InputDeviceSpecification<TInput>, new()
-    {
-        return builder.WithInputMap(input, actionKey);
-    }
-
-    #region Helpers
-
-    private static string GetMethodName<T>(Expression<Func<T, object?>> expression)
-    {
-        Expression body = expression.Body;
-
-        // Handle boxing/unboxing if the method returns a value type cast to object
-        if (body is UnaryExpression unary)
-        {
-            body = unary.Operand;
-        }
-
-        if (body is MethodCallExpression method)
-        {
-            return method.Method.Name;
-        }
-
-        // Also handle MemberExpression in case they pass a property that acts as an action
-        if (body is MemberExpression member)
-        {
-            return member.Member.Name;
-        }
-
-        throw new ArgumentException("Expression must be a method call (e.g., s => s.Jump())", nameof(expression));
-    }
-
-    #endregion
 }

--- a/src/OSK.Extensions.Inputs.Configuration/Internal/Services/InputSchemeBuilder.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/Internal/Services/InputSchemeBuilder.cs
@@ -25,9 +25,8 @@ internal class InputSchemeBuilder(string name, IInputSystemConfigurationBuilder 
         return this;
     }
 
-    public IInputSchemeBuilder WithDevice<TDeviceSpecification, TInput>(Action<IInputDeviceMapBuilder<TDeviceSpecification, TInput>> mapBuilderConfigurator)
-        where TInput : Enum
-        where TDeviceSpecification : InputDeviceSpecification<TInput>, new()
+    public IInputSchemeBuilder WithDevice<TDeviceSpecification>(Action<IInputDeviceMapBuilder> mapBuilderConfigurator)
+        where TDeviceSpecification : InputDeviceSpecification, new()
     {
         if (mapBuilderConfigurator is null)
         {
@@ -37,7 +36,7 @@ internal class InputSchemeBuilder(string name, IInputSystemConfigurationBuilder 
         var deviceSpecification = new TDeviceSpecification();
         configurationBuilder.WithDevice(deviceSpecification);
 
-        var mapBuilder = new InputDeviceMapBuilder<TDeviceSpecification, TInput>(deviceSpecification.DeviceFamily);
+        var mapBuilder = new InputDeviceMapBuilder(deviceSpecification);
         mapBuilderConfigurator(mapBuilder);
 
         var map = mapBuilder.Build(); ;

--- a/src/OSK.Extensions.Inputs.Configuration/Ports/IInputDeviceMapBuilder.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/Ports/IInputDeviceMapBuilder.cs
@@ -1,22 +1,15 @@
-﻿using System;
-using OSK.Inputs.Abstractions.Devices;
-
-namespace OSK.Extensions.Inputs.Configuration.Ports;
+﻿namespace OSK.Extensions.Inputs.Configuration.Ports;
 
 /// <summary>
-/// A builder that helps to more fluently create configuration for device maps, using a typed specification for input guarding
+/// A builder that helps to more fluently create configuration for device maps
 /// </summary>
-/// <typeparam name="TDeviceSpecification">The specification the builder is configuring with</typeparam>
-/// <typeparam name="TInput">The input the specification uses</typeparam>
-public interface IInputDeviceMapBuilder<TDeviceSpecification, TInput>
-    where TInput: Enum
-    where TDeviceSpecification: InputDeviceSpecification<TInput>, new()
+public interface IInputDeviceMapBuilder
 {
     /// <summary>
     /// Adds an input map
     /// </summary>
-    /// <param name="input">The input to add</param>
+    /// <param name="inputId">The id of the input to add that is on the associated devive</param>
     /// <param name="actionName">The action the input maps to</param>
     /// <returns>The builder for chaining</returns>
-    IInputDeviceMapBuilder<TDeviceSpecification, TInput> WithInputMap(TInput input, string actionName);
+    IInputDeviceMapBuilder WithInputMap(int inputId, string actionName);
 }

--- a/src/OSK.Extensions.Inputs.Configuration/Ports/IInputSchemeBuilder.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/Ports/IInputSchemeBuilder.cs
@@ -12,12 +12,10 @@ public interface IInputSchemeBuilder
     /// Adds a device map for a given specification and an actionc configurator
     /// </summary>
     /// <typeparam name="TDeviceSpecification">The device to make a map for</typeparam>
-    /// <typeparam name="TInput">The type of input the device uses</typeparam>
     /// <param name="mapBuilderConfigurator">The action configurator</param>
     /// <returns>The builder for chaining</returns>
-    IInputSchemeBuilder WithDevice<TDeviceSpecification, TInput>(Action<IInputDeviceMapBuilder<TDeviceSpecification, TInput>> mapBuilderConfigurator)
-        where TInput : Enum
-        where TDeviceSpecification : InputDeviceSpecification<TInput>, new();
+    IInputSchemeBuilder WithDevice<TDeviceSpecification>(Action<IInputDeviceMapBuilder> mapBuilderConfigurator)
+        where TDeviceSpecification : InputDeviceSpecification, new();
 
     /// <summary>
     /// Makes the scheme a default scheme

--- a/src/OSK.Inputs.Abstractions/Devices/GamePads/GamePadDeviceSpecification.cs
+++ b/src/OSK.Inputs.Abstractions/Devices/GamePads/GamePadDeviceSpecification.cs
@@ -4,7 +4,7 @@ using OSK.Inputs.Abstractions.Inputs;
 
 namespace OSK.Inputs.Abstractions.Devices.GamePads;
 
-public abstract class GamePadDeviceSpecification : InputDeviceSpecification
+public abstract class GamePadDeviceSpecification : InputDeviceSpecification<GamePadInput>
 {
     #region InputDeviceSpecification Overrides
 


### PR DESCRIPTION
Motivation
----
Utilizing the builder in an editor configuration has been more difficult due to the fact that the type guard constraint is required. This prevents an editor setup as there'd be a need to know the exact <T> for the device and input it uses. Updating to make this configuration easier and to still allow type guarding if desired

Modifications
----
* Remove <T> mandate on IInputDeviceMapBuilder and related builders
* Utilize the InputDeviceSpecification in the base form to validate inputs against the devices as they are configured

Result
----
It's easier to configure in an editor

Fixes #47