### PR TITLE
Update extension name for Inputs and update docs (OSK-56)

### DIFF
--- a/src/OSK.Extensions.Inputs.Configuration/Attributes/InputActionAttribute.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/Attributes/InputActionAttribute.cs
@@ -4,6 +4,9 @@ using OSK.Inputs.Abstractions.Inputs;
 
 namespace OSK.Extensions.Inputs.Configuration.Attributes;
 
+/// <summary>
+/// An attribute that can be used to provide extra context for input methods being used with an input processor
+/// </summary>
 [AttributeUsage(AttributeTargets.Method)]
 public class InputActionAttribute : Attribute
 {

--- a/src/OSK.Extensions.Inputs.Configuration/Options/InputActionOptions.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/Options/InputActionOptions.cs
@@ -2,11 +2,24 @@
 
 namespace OSK.Extensions.Inputs.Configuration.Options;
 
+/// <summary>
+/// A set of options specific to input actions
+/// </summary>
 public class InputActionOptions
 {
+    /// <summary>
+    /// An optional grouping that can be used to group specific input actions together. i.e. group pointer actions or similar so that they can be manipulated as group. This is best used when wanting to suppress
+    /// groups of input, as an example.
+    /// </summary>
     public int? ActionGroup { get; set; }
 
+    /// <summary>
+    /// Extra input streams that are included with the action. For example, an input action can include the pointer input stream data if it is relevant to the action's execution
+    /// </summary>
     public InputStreamType[] IncludedInputStreams { get; set; } = [];
 
+    /// <summary>
+    /// Describes the input action, best utilized with UI for input configuration
+    /// </summary>
     public string? Description { get; set; }
 }

--- a/src/OSK.Extensions.Inputs.Configuration/Options/InputProcessingOptions.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/Options/InputProcessingOptions.cs
@@ -3,6 +3,9 @@ using OSK.Inputs.Abstractions.Inputs;
 
 namespace OSK.Extensions.Inputs.Configuration.Options;
 
+/// <summary>
+/// Defines options that are utilized with an input processor
+/// </summary>
 public class InputProcessingOptions
 {
     /// <summary>

--- a/src/OSK.Extensions.Inputs.Configuration/Options/InputSystemJoinPolicyOptions.cs
+++ b/src/OSK.Extensions.Inputs.Configuration/Options/InputSystemJoinPolicyOptions.cs
@@ -2,11 +2,23 @@
 
 namespace OSK.Extensions.Inputs.Configuration.Options;
 
+/// <summary>
+/// Defines a set of options to configure the join policy of the input system
+/// </summary>
 public class InputSystemJoinPolicyOptions
 {
+    /// <summary>
+    /// Informs the input system of the total local users to expect to join and play the game. Players are joined up to the limit, based on the <see cref="UserJoinBehavior"/>
+    /// </summary>
     public int MaxLocalUsers { get; set; }
 
+    /// <summary>
+    /// Describes how pairing a new device should occur
+    /// </summary>
     public DevicePairingBehavior DevicePairingBehavior { get; set; }
 
+    /// <summary>
+    /// Describes the behavior the input system uses when encountering a potential new user
+    /// </summary>
     public UserJoinBehavior UserJoinBehavior { get; set; }
 }

--- a/src/OSK.Inputs.Abstractions/Runtime/PointerStreamDetails.cs
+++ b/src/OSK.Inputs.Abstractions/Runtime/PointerStreamDetails.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using OSK.Inputs.Abstractions.Inputs;
 
 namespace OSK.Inputs.Abstractions.Runtime;
 

--- a/src/OSK.Inputs/Exceptions/InputSystemValidationException.cs
+++ b/src/OSK.Inputs/Exceptions/InputSystemValidationException.cs
@@ -2,6 +2,10 @@
 
 namespace OSK.Inputs.Exceptions;
 
+/// <summary>
+/// Ann exception that is specific to the input system validation process
+/// </summary>
+/// <param name="message">The error message</param>
 public class InputSystemValidationException(string message) : Exception(message)
 {
 }

--- a/src/OSK.Inputs/Internal/Services/InputSystemBuilder.cs
+++ b/src/OSK.Inputs/Internal/Services/InputSystemBuilder.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OSK.Inputs.Abstractions;
+using OSK.Inputs.Ports;
+
+namespace OSK.Inputs.Internal.Services;
+
+internal class InputSystemBuilder(IServiceCollection services) : IInputSystemBuilder
+{
+    #region IInputSystemBuilder
+
+    public IInputSystemBuilder UseSchemeRepository<TSchemeRepository>() 
+        where TSchemeRepository : class, IInputSchemeRepository
+    {
+        services.TryAddSingleton<IInputSchemeRepository, TSchemeRepository>();
+
+        return this;
+    }
+
+    #endregion
+}

--- a/src/OSK.Inputs/OSK.Inputs.csproj
+++ b/src/OSK.Inputs/OSK.Inputs.csproj
@@ -10,11 +10,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.1" />
-		<PackageReference Include="OSK.Expressions.Invoker" Version="1.1.0" />
-		<PackageReference Include="PolySharp" Version="1.15.0">
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+		<PackageReference Include="OSK.Expressions.Invoker" Version="1.2.2" />
+		<PackageReference Include="PolySharp" Version="1.16.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/src/OSK.Inputs/Ports/IInputSystem.cs
+++ b/src/OSK.Inputs/Ports/IInputSystem.cs
@@ -74,7 +74,12 @@ public interface IInputSystem
     /// <summary>
     /// Updates the input system using the specified delta time
     /// </summary>
-    /// <remarks>This process method may be ignored by the input system if the input system is pausing input</remarks>
+    /// <remarks>
+    /// 💡Notes:
+    /// <list type="bullet">
+    /// <item>This process method may be ignored by the input system if the input system is pausing input</item>
+    /// </list>
+    /// </remarks>
     /// <param name="deltaTime">the time that has passed since the last update</param>
     void Update(TimeSpan deltaTime);
 }

--- a/src/OSK.Inputs/Ports/IInputSystemBuilder.cs
+++ b/src/OSK.Inputs/Ports/IInputSystemBuilder.cs
@@ -1,0 +1,19 @@
+﻿using OSK.Hexagonal.MetaData;
+using OSK.Inputs.Abstractions;
+
+namespace OSK.Inputs.Ports;
+
+/// <summary>
+/// A builder that is used to configure the input system
+/// </summary>
+[HexagonalIntegration(HexagonalIntegrationType.LibraryProvided)]
+public interface IInputSystemBuilder
+{
+    /// <summary>
+    /// Specifies the specific input scheme repository to use 
+    /// </summary>
+    /// <typeparam name="TSchemeRepository">The input scheme repository that is desired</typeparam>
+    /// <returns>The builder for chaining</returns>
+    IInputSystemBuilder UseSchemeRepository<TSchemeRepository>()
+        where TSchemeRepository: class, IInputSchemeRepository;
+}

--- a/src/OSK.Inputs/Ports/IInputUserManager.cs
+++ b/src/OSK.Inputs/Ports/IInputUserManager.cs
@@ -85,10 +85,12 @@ public interface IInputUserManager
     /// Updates and loads the input system configuration with user specified data.
     /// </summary>
     /// <remarks>
-    /// It is important that this is run after a user saves, deletes, or performs any changes to persistent storage to ensure that the changes
-    /// are reflected in the input system
+    /// 💡Notes:
+    /// <list type="bullet">
+    /// <item> It is important that this is run after a user saves, deletes, or performs any changes to persistent storage to ensure that the changes are reflected in the input system</item>
+    /// </list>
     /// </remarks>
-    /// <param name="cancellationToken"></param>
-    /// <returns></returns>
+    /// <param name="cancellationToken">A token to cancel the operation</param>
+    /// <returns>An output that describes if hte load succeeded</returns>
     Task<Output> LoadUserConfigurationAsync(CancellationToken cancellationToken = default);
 }

--- a/src/OSK.Inputs/ServiceCollectionExtensions.cs
+++ b/src/OSK.Inputs/ServiceCollectionExtensions.cs
@@ -19,8 +19,14 @@ public static class ServiceCollectionExtensions
         => services.AddInputSystem(_ => { });
 
     /// <summary>
-    /// Adds the core services for the input system and processing to the service collection
+    /// Adds the core services for the input system and processing to the service collection.
     /// </summary>
+    /// <remarks>
+    /// 💡Notes:
+    /// <list type="bullet">
+    /// <item>If no scheme repository is specified with the input system builder, a default in-memory one will be utilized</item>
+    /// </list>
+    /// </remarks>
     /// <param name="services">The services to add the DI to</param>
     /// <param name="configurator">The action to configure the input system</param>
     /// <returns>The service collection for chaining</returns>
@@ -43,6 +49,8 @@ public static class ServiceCollectionExtensions
         services.TryAddSingleton<IInputConfigurationProvider, InputConfigurationProvider>();
 
         var builder = new InputSystemBuilder(services);
+        configurator(builder);
+
         builder.UseSchemeRepository<InMemorySchemeRepository>();
 
         return services;

--- a/src/OSK.Inputs/ServiceCollectionExtensions.cs
+++ b/src/OSK.Inputs/ServiceCollectionExtensions.cs
@@ -1,7 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OSK.Inputs.Abstractions;
-using OSK.Inputs.Exceptions;
 using OSK.Inputs.Internal;
 using OSK.Inputs.Internal.Services;
 using OSK.Inputs.Ports;
@@ -11,12 +11,27 @@ namespace OSK.Inputs;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
+    /// Adds the core services for the input system and processing to the service collection, using default configuration
+    /// </summary>
+    /// <param name="services">The services to add the DI to</param>
+    /// <returns>The service collection for chaining</returns>
+    public static IServiceCollection AddInputSystem(this IServiceCollection services)
+        => services.AddInputSystem(_ => { });
+
+    /// <summary>
     /// Adds the core services for the input system and processing to the service collection
     /// </summary>
+    /// <param name="services">The services to add the DI to</param>
+    /// <param name="configurator">The action to configure the input system</param>
     /// <returns>The service collection for chaining</returns>
-    /// <exception cref="InputSystemValidationException">Thrown if the input system configuration provided by the source was invalid</exception>
-    public static IServiceCollection AddInputs(this IServiceCollection services)
+    /// <exception cref="ArgumentNullException">Thrown if the input system configuration build configurator is null</exception>
+    public static IServiceCollection AddInputSystem(this IServiceCollection services, Action<IInputSystemBuilder> configurator)
     {
+        if (configurator is null)
+        {
+            throw new ArgumentNullException(nameof(configurator));
+        }
+
         services.TryAddTransient<IInputSystemConfigurationValidator, InputSystemConfigurationValidator>();
 
         services.TryAddScoped<IInputProcessor, InputProcessor>();
@@ -27,17 +42,8 @@ public static class ServiceCollectionExtensions
 
         services.TryAddSingleton<IInputConfigurationProvider, InputConfigurationProvider>();
 
-        return services;
-    }
-
-    /// <summary>
-    /// Adds an <see cref="IInputSchemeRepository"/> that uses an in memory backend, so scheme preferences will not be kept in persistence storage.
-    /// This scheme repository does not support custom schemes.
-    /// </summary>
-    /// <returns>The service collection for chaining</returns>
-    public static IServiceCollection AddInMemorySchemeRepository(this IServiceCollection services)
-    {
-        services.AddSingleton<IInputSchemeRepository, InMemorySchemeRepository>();
+        var builder = new InputSystemBuilder(services);
+        builder.UseSchemeRepository<InMemorySchemeRepository>();
 
         return services;
     }


### PR DESCRIPTION
Motivation
----
We'd like to make the behavior a bit easier to use with the default memory scheme repository. As of now, a user must add the memory repository, a default, explicitly, rather than a simple implicit usage if no specific override is set. This can cause an oddity in the runtime when the servies are built and an error thrown because the expectation was to use the memory by default

Modifications
----
* Update the input extension naming scheme and parameter requirements to allow for a default of using memory scheme repository, with optional override
* Added docs

Result
----
A hopefully more streamlined usage of the library extension and better docs

Fixes #56